### PR TITLE
The manifests/ docs should use the latest (non dev) image versions

### DIFF
--- a/crossplane-api/README.md
+++ b/crossplane-api/README.md
@@ -277,7 +277,7 @@ To install the configuration package (containing definitions and compositions), 
 1. Install the package via crossplane:
 
 ```bash
-crossplane xpkg install configuration public.ecr.aws/w5n9a2g2/anynines/dataservices:v1.2.0
+crossplane xpkg install configuration public.ecr.aws/w5n9a2g2/anynines/dataservices:v1.3.0
 ```
 
 2. Install files directly:

--- a/crossplane-api/deploy/config-pkg-anynines.yaml
+++ b/crossplane-api/deploy/config-pkg-anynines.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: anynines-dataservices
 spec:
-  package: public.ecr.aws/w5n9a2g2/anynines/dataservices:v1.2.0
+  package: public.ecr.aws/w5n9a2g2/anynines/dataservices:v1.3.0

--- a/crossplane-api/deploy/provider-anynines.yaml
+++ b/crossplane-api/deploy/provider-anynines.yaml
@@ -3,7 +3,7 @@ kind: Provider
 metadata:
   name: provider-anynines
 spec:
-  package: "public.ecr.aws/w5n9a2g2/anynines/provider-anynines:v1.2.0-c4316f2b85fb54edcc4852e2a7e503bb09354159"
+  package: "public.ecr.aws/w5n9a2g2/anynines/provider-anynines:v1.3.0"
   runtimeConfigRef:
     name: provider-anynines
 ---

--- a/docs/platform-operator/monitoring.md
+++ b/docs/platform-operator/monitoring.md
@@ -18,7 +18,7 @@ condition of the installed crossplane providers:
 $ kubectl get providers
 NAME                                     INSTALLED   HEALTHY   PACKAGE                                                         AGE
 crossplane-contrib-provider-kubernetes   True        True      xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.9.0   118m
-provider-anynines                        True        True      public.ecr.aws/w5n9a2g2/anynines/provider-anynines:v1.2.0       118m
+provider-anynines                        True        True      public.ecr.aws/w5n9a2g2/anynines/provider-anynines:v1.3.0       118m
 ```
 
 If one of the underlying pods encounters an error and needs to be recreated, the HEALTHY condition

--- a/provider-anynines/examples/provider/provider.yaml
+++ b/provider-anynines/examples/provider/provider.yaml
@@ -3,4 +3,4 @@ kind: Provider
 metadata:
   name: provider-anynines
 spec:
-  package: "public.ecr.aws/w5n9a2g2/anynines/provider-anynines:v1.2.0"
+  package: "public.ecr.aws/w5n9a2g2/anynines/provider-anynines:v1.3.0"

--- a/test/e2e/provider/manifests/configuration.yaml
+++ b/test/e2e/provider/manifests/configuration.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: anynines-dataservices
 spec:
-  package: public.ecr.aws/w5n9a2g2/anynines/dataservices:v1.2.0
+  package: public.ecr.aws/w5n9a2g2/anynines/dataservices:v1.3.0

--- a/test/e2e/provider/manifests/install/provider.yaml
+++ b/test/e2e/provider/manifests/install/provider.yaml
@@ -3,6 +3,6 @@ kind: Provider
 metadata:
   name: anynines-provider
 spec:
-  package: public.ecr.aws/w5n9a2g2/anynines/provider-anynines:v1.2.0
+  package: public.ecr.aws/w5n9a2g2/anynines/provider-anynines:v1.3.0
   runtimeConfigRef:
     name: enable-debug-logging


### PR DESCRIPTION
I installed Klutch using this repository and noticed that the versions I rolled out are not the latest ones, so I bumped the versions in the docs and the manifest to v1.3.0 which seems to be latest for provider-anynines and the anynines configurations. 

I think at some point in the future this should be automated. 

WARNING: Only users listed in the CODEOWNERS file can approve PRs!
