### PR TITLE
Fix broken link of klutchio docs

### DIFF
--- a/docs/platform-operator-guide/update-klutch-components.md
+++ b/docs/platform-operator-guide/update-klutch-components.md
@@ -74,7 +74,7 @@ Before proceeding, review the changelog for the new version and follow any migra
 
 3. **Introduce New Data Service Types**
 
-    If the update includes new data service types, implement the [binding creation steps](https://klutch.io/docs/platform-operator/binding-creation)
+    If the update includes new data service types, implement the [binding creation steps](../platform-operator-guide/setting-up-klutch-clusters/app-cluster.md)
     to make them available in App Clusters.
 
 **Downtime Considerations During Updates**


### PR DESCRIPTION
The link was outdated due to a change in the documentation structure a few months ago. This fix now updates the link to the correct file.

WARNING: Only users listed in the CODEOWNERS file can approve PRs!
