### PR TITLE
fix: remove unsupported a9s Messaging 3.x versions from XMessagingInstance XRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Klutch-bind: migrated APIServiceBinding handling to namespace scope as part of control plane mode hardening.
 - Klutch-bind: updated control plane mode root namespace handling for app cluster kubeconfig and simplified AppClusterBinding RBAC.
 
+### Removed
+
+- **breaking**: Removed unsupported a9s Messaging service versions `a9s-messaging310`, `a9s-messaging312`, and `a9s-messaging313` from the `XMessagingInstance` XRD. These versions were discontinued in DSF v57.0.0 and v65.0.0 respectively. Claims using these versions are now rejected at admission time.
+
 ## [1.5.0] - 2026-05-26
 
 ### Added

--- a/crossplane-api/api/a9s/messaging/definition.yaml
+++ b/crossplane-api/api/a9s/messaging/definition.yaml
@@ -36,10 +36,7 @@ spec:
                 ]
             - services:
                 &messagingServices [
-                  "a9s-messaging310",
-                  "a9s-messaging312",
-                  "a9s-messaging313",
-                  "a9s-messaging4",                  
+                  "a9s-messaging4",
                 ]
           properties:
             spec:


### PR DESCRIPTION
## Summary

- Removes `a9s-messaging310`, `a9s-messaging312`, and `a9s-messaging313` from the `&messagingServices` enum anchor in the `XMessagingInstance` XRD (`crossplane-api/api/a9s/messaging/definition.yaml`)
- Updates `CHANGELOG.md` with a `### Removed` entry under `## Unreleased` marking the removal as breaking

These three versions were discontinued in DSF v57.0.0 (3.10) and v65.0.0 (3.12, 3.13). The current DSF version is v72.0.0. Without this fix, users requesting these versions receive no upfront rejection — the claim is accepted, a `MessagingInstance` is created, and `provider-anynines` attempts provisioning silently until it fails.

After this change, Kubernetes schema validation rejects claims with deprecated service values at `kubectl apply` time.

## Test plan

- [ ] Apply a `MessagingInstance` claim with `spec.service: a9s-messaging310` → rejected by Kubernetes with schema validation error
- [ ] Repeat for `a9s-messaging312` and `a9s-messaging313` → both rejected
- [ ] Apply a `MessagingInstance` claim with `spec.service: a9s-messaging4` → accepted (no regression)
- [ ] Verify via `kubectl get crd xmessaginginstances.anynines.com -o yaml` that `spec.service.enum` contains only `a9s-messaging4`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This change only removes enum values from a CRD schema — it does not affect runtime behavior for valid claims or existing provisioned instances. Operators should audit running `MessagingInstance` resources for deprecated service versions before applying the updated CRD, as noted in the plan's deferred work.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Compound Engineering](https://github.com/anynines/klutchio)