### PR TITLE
Klt 1022 enforce crossplane v 2 secret isolation contract across all service integrations

### DIFF
--- a/crossplane-api/README.md
+++ b/crossplane-api/README.md
@@ -99,7 +99,7 @@ Then push the multi-arch controller image to ECR:
 make provider-controller-build-push IMAGETAG=<version-or-ticket-id>
 
 #example
-make provider-controller-build-push IMAGETAG=KLT-877
+make provider-controller-build-push IMAGETAG=v2.0.0
 ```
 
 ### Build and push provider package
@@ -112,7 +112,7 @@ execute the following command:
 make provider-build-push IMAGETAG=<version-or-ticket-id>
 
 #example
-make provider-build-push IMAGETAG=KLT-877
+make provider-build-push IMAGETAG=v2.0.0
 ```
 
 ## Optional: Build and push anynines-dataservices Package
@@ -158,7 +158,7 @@ configuration package we want to set.
 make -C crossplane-api/ dataservices-config-push dataservicesConfigVersion=<image version>
 
 # example
-make -C crossplane-api/ dataservices-config-push dataservicesConfigVersion=KLT-877
+make -C crossplane-api/ dataservices-config-push dataservicesConfigVersion=v2.0.0
 ```
 
 ## Installation
@@ -270,7 +270,7 @@ To install the configuration package (containing definitions and compositions), 
 1. Install the package via crossplane:
 
 ```bash
-crossplane xpkg install configuration public.ecr.aws/h6x7g6i7/klutch/dataservices:KLT-877
+crossplane xpkg install configuration public.ecr.aws/h6x7g6i7/klutch/dataservices:KLT-1022-v2
 ```
 
 1. Install files directly:

--- a/crossplane-api/api/a8s/backup/composition.yaml
+++ b/crossplane-api/api/a8s/backup/composition.yaml
@@ -34,13 +34,8 @@ spec:
                 transforms:
                   - type: string
                     string:
-                      type: Regexp
-                      regexp:
-                        match: '^(.{1,58}).*$'
-                  - type: string
-                    string:
                       type: Format
-                      fmt: "%s-dsi"
+                      fmt: "%s-internal"
               - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
               - fromFieldPath: spec.serviceInstanceType
@@ -70,11 +65,6 @@ spec:
               - type: ToCompositeFieldPath
                 fromFieldPath: status.atProvider.manifest.status.lastObservationTime
                 toFieldPath: status.managed.lastObservationTime
-                policy:
-                  fromFieldPath: Optional
-              - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.manifest.status.podUsedNamespacedName
-                toFieldPath: status.managed.podUsedNamespacedName
                 policy:
                   fromFieldPath: Optional
               - type: ToCompositeFieldPath

--- a/crossplane-api/api/a8s/postgresql/composition.yaml
+++ b/crossplane-api/api/a8s/postgresql/composition.yaml
@@ -28,39 +28,19 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
-          # We create a "Data Service Instance" (DSI) namespace to host the actual
-          # database pods and secrets. This keeps sensitive admin credentials
-          # hidden from the user's namespace.
-          - name: postgresql-internal-namespace
-            base:
-              apiVersion: kubernetes.m.crossplane.io/v1alpha1
-              kind: Object
-              spec:
-                forProvider:
-                  manifest:
-                    apiVersion: v1
-                    kind: Namespace
-                providerConfigRef:
-                  name: kubernetes-provider
-                  kind: ClusterProviderConfig
-            patches:
-              - fromFieldPath: metadata.namespace
-                toFieldPath: spec.forProvider.manifest.metadata.name
-                transforms:
-                  # Namespace max length is 63. Keep 58 chars and append "-dsi".
-                  - type: string
-                    string:
-                      type: Regexp
-                      regexp:
-                        match: '^(.{1,58}).*$'
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-dsi"
+          # The Postgresql operator (postgresql.anynines.com/v1beta3 Postgresql) and
+          # its pods/secrets/admin credentials are hosted in an "-internal"
+          # namespace whose name is derived by suffixing the synced namespace (the
+          # one shared between the app cluster and the control plane cluster) with
+          # "-internal". klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a8s-postgresql
             base:
               apiVersion: kubernetes.m.crossplane.io/v1alpha1
               kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a8s-postgresql
               spec:
                 forProvider:
                   manifest:
@@ -78,13 +58,8 @@ spec:
                   # Place the a8s Postgresql object in the internal namespace.
                   - type: string
                     string:
-                      type: Regexp
-                      regexp:
-                        match: '^(.{1,58}).*$'
-                  - type: string
-                    string:
                       type: Format
-                      fmt: "%s-dsi"
+                      fmt: "%s-internal"
               - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
               - fromFieldPath: spec.service

--- a/crossplane-api/api/a8s/restore/composition.yaml
+++ b/crossplane-api/api/a8s/restore/composition.yaml
@@ -34,13 +34,8 @@ spec:
                 transforms:
                   - type: string
                     string:
-                      type: Regexp
-                      regexp:
-                        match: '^(.{1,58}).*$'
-                  - type: string
-                    string:
                       type: Format
-                      fmt: "%s-dsi"
+                      fmt: "%s-internal"
               - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
               - fromFieldPath: spec.serviceInstanceType
@@ -72,11 +67,6 @@ spec:
               - type: ToCompositeFieldPath
                 fromFieldPath: status.atProvider.manifest.status.podToPoll.ip
                 toFieldPath: status.managed.podToPoll.ip
-                policy:
-                  fromFieldPath: Optional
-              - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.manifest.status.podToPoll.namespacedName
-                toFieldPath: status.managed.podToPoll.namespacedName
                 policy:
                   fromFieldPath: Optional
               - type: ToCompositeFieldPath

--- a/crossplane-api/api/a8s/servicebinding/composition.yaml
+++ b/crossplane-api/api/a8s/servicebinding/composition.yaml
@@ -27,162 +27,20 @@ spec:
                 providerConfigRef:
                   name: kubernetes-provider
                   kind: ClusterProviderConfig
-                # Credential Secret written to the ServiceBinding namespace and populated
-                # from the a8s ServiceBinding secret (<name>-service-binding in
-                # <namespace>-dsi). Name defaults to <name>-pg-creds; can be
-                # overridden by spec.writeConnectionSecretToRef.name.
-                writeConnectionSecretToRef:
-                  name: placeholder
-                connectionDetails:
-                - apiVersion: v1
-                  kind: Secret
-                  name: placeholder
-                  namespace: placeholder
-                  fieldPath: data.password
-                  toConnectionSecretKey: password
-                - apiVersion: v1
-                  kind: Secret
-                  name: placeholder
-                  namespace: placeholder
-                  fieldPath: data.username
-                  toConnectionSecretKey: username
-                - apiVersion: v1
-                  kind: Secret
-                  name: placeholder
-                  namespace: placeholder
-                  fieldPath: data.database
-                  toConnectionSecretKey: database
-                - apiVersion: v1
-                  kind: Secret
-                  name: placeholder
-                  namespace: placeholder
-                  fieldPath: data.instance_service
-                  toConnectionSecretKey: instance_service
-            connectionDetails:
-              - type: FromConnectionSecretKey
-                name: password
-                fromConnectionSecretKey: password
-              - type: FromConnectionSecretKey
-                name: username
-                fromConnectionSecretKey: username
-              - type: FromConnectionSecretKey
-                name: database
-                fromConnectionSecretKey: database
-              - type: FromConnectionSecretKey
-                name: instance_service
-                fromConnectionSecretKey: instance_service
             patches:
               # ServiceBinding CR must be in the same namespace as the PostgreSQL
-              # instance (<namespace>-dsi) to satisfy the a8s controller's requirement
+              # instance (<namespace>-internal) to satisfy the a8s controller's requirement
               # that owner references cannot cross namespaces.
               - fromFieldPath: metadata.namespace
                 toFieldPath: spec.forProvider.manifest.metadata.namespace
                 transforms:
                   - type: string
                     string:
-                      type: Regexp
-                      regexp:
-                        match: '^(.{1,58}).*$'
-                  - type: string
-                    string:
                       type: Format
-                      fmt: "%s-dsi"
+                      fmt: "%s-internal"
               - fromFieldPath: metadata.name
                 toFieldPath: spec.forProvider.manifest.metadata.name
 
-              # Read connection details from the a8s generated secret
-              # (<name>-service-binding in <namespace>-dsi).
-              # This location must be updated if the servicebinding controller
-              # changes its namespace or naming scheme.
-              # It is currently necessary to patch the location once per key
-              # because of the way provider-kubernetes handles ConnectionDetail
-              # sources.
-              - fromFieldPath: metadata.namespace
-                toFieldPath: spec.connectionDetails[0].namespace
-                transforms:
-                  - type: string
-                    string:
-                      type: Regexp
-                      regexp:
-                        match: '^(.{1,58}).*$'
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-dsi"
-              - fromFieldPath: metadata.name
-                toFieldPath: spec.connectionDetails[0].name
-                transforms:
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-service-binding"
-              - fromFieldPath: metadata.namespace
-                toFieldPath: spec.connectionDetails[1].namespace
-                transforms:
-                  - type: string
-                    string:
-                      type: Regexp
-                      regexp:
-                        match: '^(.{1,58}).*$'
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-dsi"
-              - fromFieldPath: metadata.name
-                toFieldPath: spec.connectionDetails[1].name
-                transforms:
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-service-binding"
-              - fromFieldPath: metadata.namespace
-                toFieldPath: spec.connectionDetails[2].namespace
-                transforms:
-                  - type: string
-                    string:
-                      type: Regexp
-                      regexp:
-                        match: '^(.{1,58}).*$'
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-dsi"
-              - fromFieldPath: metadata.name
-                toFieldPath: spec.connectionDetails[2].name
-                transforms:
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-service-binding"
-              - fromFieldPath: metadata.namespace
-                toFieldPath: spec.connectionDetails[3].namespace
-                transforms:
-                  - type: string
-                    string:
-                      type: Regexp
-                      regexp:
-                        match: '^(.{1,58}).*$'
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-dsi"
-              - fromFieldPath: metadata.name
-                toFieldPath: spec.connectionDetails[3].name
-                transforms:
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-service-binding"
-
-              # Raw relay Secret used to flow credentials through the pipeline.
-              # Name is fixed; the user-facing complete Secret is created by create-connection-secret.
-              - fromFieldPath: metadata.name
-                toFieldPath: spec.writeConnectionSecretToRef.name
-                transforms:
-                  - type: string
-                    string:
-                      type: Format
-                      fmt: "%s-pg-creds-raw"
               - fromFieldPath: spec.serviceInstanceType
                 toFieldPath: spec.forProvider.manifest.spec.instance.apiVersion
                 transforms:
@@ -200,13 +58,8 @@ spec:
                 transforms:
                   - type: string
                     string:
-                      type: Regexp
-                      regexp:
-                        match: '^(.{1,58}).*$'
-                  - type: string
-                    string:
                       type: Format
-                      fmt: "%s-dsi"
+                      fmt: "%s-internal"
               - fromFieldPath: spec.instanceRef
                 toFieldPath: spec.forProvider.manifest.spec.instance.name
               - type: ToCompositeFieldPath
@@ -214,16 +67,29 @@ spec:
                 toFieldPath: status.managed.implemented
                 policy:
                   fromFieldPath: Optional
-              - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.manifest.status.secret.name
-                toFieldPath: status.managed.secret.name
-                policy:
-                  fromFieldPath: Optional
-              - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.manifest.status.secret.namespace
-                toFieldPath: status.managed.secret.namespace
-                policy:
-                  fromFieldPath: Optional
+    # Requests the a8s-operator-written credentials Secret (<name>-service-binding)
+    # from the -internal namespace via function-go-templating's built-in ExtraResources
+    # requirement. Crossplane's core controller performs the read directly into the
+    # pipeline context; no Kubernetes object is created, so the raw credentials never
+    # exist as a resource outside the -internal namespace.
+    - step: request-credentials-secret
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            {{- $xr := $.observed.composite.resource }}
+            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+            kind: ExtraResources
+            requirements:
+              credentials-secret:
+                apiVersion: v1
+                kind: Secret
+                matchName: {{ printf "%s-service-binding" $xr.metadata.name }}
+                namespace: {{ printf "%s-internal" $xr.metadata.namespace }}
     - step: create-connection-secret
       functionRef:
         name: function-go-templating
@@ -233,19 +99,26 @@ spec:
         source: Inline
         inline:
           template: |
-            {{- $xr := getCompositeResource . -}}
-            {{- $ns := $xr.metadata.namespace -}}
-            {{- with $.observed.resources }}
-            {{- if ne (index $.observed.resources "a8s-servicebinding") nil }}
-            {{- $sb := (index $.observed.resources "a8s-servicebinding") }}
-            {{- $connectionDetails := $sb.connectionDetails | default dict }}
-            {{- $username := index $connectionDetails "username" | default "" }}
+            {{- $xr := $.observed.composite.resource }}
+            {{- $ns := $xr.metadata.namespace }}
+            {{- $extraRes := index $.context "apiextensions.crossplane.io/extra-resources" | default dict }}
+            {{- $credEntry := index $extraRes "credentials-secret" | default dict }}
+            {{- $credItems := index $credEntry "items" | default (list) }}
+            {{- $credData := dict }}
+            {{- if gt (len $credItems) 0 }}
+            {{- $credData = (index $credItems 0).resource.data | default dict }}
+            {{- end }}
+            {{- $username := index $credData "username" | default "" }}
             {{- if $username }}
-            {{- $password := index $connectionDetails "password" | default "" }}
-            {{- $database := index $connectionDetails "database" | default "" }}
-            {{- $instanceService := index $connectionDetails "instance_service" | default "" }}
-            {{- $host := printf "%s-master.%s" $sb.resource.spec.forProvider.manifest.spec.instance.name $sb.resource.spec.forProvider.manifest.spec.instance.namespace }}
-            {{- $secretName := dig "spec" "writeConnectionSecretToRef" "name" (printf "%s-pg-creds" $xr.metadata.name) $xr }}
+            {{- $password := index $credData "password" | default "" }}
+            {{- $database := index $credData "database" | default "" }}
+            {{- $instanceService := index $credData "instance_service" | default "" }}
+            {{- $sbInstance := dict }}
+            {{- if and $.observed.resources (hasKey $.observed.resources "a8s-servicebinding") }}
+            {{- $sbInstance = (index $.observed.resources "a8s-servicebinding").resource.spec.forProvider.manifest.spec.instance }}
+            {{- end }}
+            {{- $host := printf "%s-master.%s" (index $sbInstance "name" | default "") (index $sbInstance "namespace" | default "") }}
+            {{- $secretName := dig "spec" "writeConnectionSecretToRef" "name" (printf "%s-creds" $xr.metadata.name) $xr }}
             apiVersion: v1
             kind: Secret
             metadata:
@@ -262,6 +135,4 @@ spec:
               instance_service: {{ $instanceService }}
               host: {{ $host | b64enc }}
               port: {{ "5432" | b64enc }}
-            {{- end }}
-            {{- end }}
             {{- end }}

--- a/crossplane-api/api/a9s/backup/composition.yaml
+++ b/crossplane-api/api/a9s/backup/composition.yaml
@@ -15,38 +15,82 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real Backup (dataservices.anynines.com/v1 Backup) is hosted in an
+          # "-internal" namespace whose name is derived by suffixing the synced
+          # namespace (the one shared between the app cluster and the control
+          # plane cluster) with "-internal", next to the ServiceInstance it
+          # references. klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a9s-backup
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: Backup
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-backup
+              spec:
+                forProvider:
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: Backup
+                providerConfigRef:
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
+                readiness:
+                  policy: DeriveFromObject
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.labels[crossplane.io/composite]
               - fromFieldPath: spec.instanceRef
-                toFieldPath: spec.forProvider.instanceName
-              - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.downloadable
-                toFieldPath: status.managed.downloadable
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.instanceName
               - fromFieldPath: spec.serviceInstanceType
-                toFieldPath: spec.providerConfigRef.name
+                toFieldPath: spec.forProvider.manifest.spec.providerConfigRef.name
                 transforms:
                   - type: string
                     string:
                       type: Format
                       fmt: "%s-backup-manager"
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.finished_at
+                fromFieldPath: status.atProvider.manifest.status.atProvider.downloadable
+                toFieldPath: status.managed.downloadable
+                policy:
+                  fromFieldPath: Optional
+              - type: ToCompositeFieldPath
+                fromFieldPath: status.atProvider.manifest.status.atProvider.finished_at
                 toFieldPath: status.managed.finished_at
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.id
+                fromFieldPath: status.atProvider.manifest.status.atProvider.id
                 toFieldPath: status.managed.id
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.size
+                fromFieldPath: status.atProvider.manifest.status.atProvider.size
                 toFieldPath: status.managed.size
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.status
+                fromFieldPath: status.atProvider.manifest.status.atProvider.status
                 toFieldPath: status.managed.status
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.triggered_at
+                fromFieldPath: status.atProvider.manifest.status.atProvider.triggered_at
                 toFieldPath: status.managed.triggered_at
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
+                policy:
+                  fromFieldPath: Optional

--- a/crossplane-api/api/a9s/keyvalue/composition.yaml
+++ b/crossplane-api/api/a9s/keyvalue/composition.yaml
@@ -15,83 +15,121 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real ServiceInstance (dataservices.anynines.com/v1 ServiceInstance)
+          # and its admin credentials are hosted in an "-internal" namespace whose
+          # name is derived by suffixing the synced namespace (the one shared
+          # between the app cluster and the control plane cluster) with
+          # "-internal". klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a9s-keyvalue
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: ServiceInstance
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-keyvalue
               spec:
                 forProvider:
-                  # acceptsIncomplete indicates if the service broker can fulfill a
-                  # request asynchronously. Since the anynines-provider controller
-                  # reconciles the resources asynchronously, if 'acceptsIncomplete' is
-                  # not specified by the user, it will default to 'true'.
-                  acceptsIncomplete: true
-                  # OrganizationGUID is the platform GUID for the organization under
-                  # which the service is to be provisioned. This value is specific to
-                  # Cloud Foundry.
-                  organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
-                  # SpaceGUID is the identifier for the project space within the
-                  # platform organization. This value is specific to Cloud Foundry.
-                  spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: ServiceInstance
+                    spec:
+                      forProvider:
+                        # acceptsIncomplete indicates if the service broker can fulfill a
+                        # request asynchronously. Since the anynines-provider controller
+                        # reconciles the resources asynchronously, if 'acceptsIncomplete' is
+                        # not specified by the user, it will default to 'true'.
+                        acceptsIncomplete: true
+                        # OrganizationGUID is the platform GUID for the organization under
+                        # which the service is to be provisioned. This value is specific to
+                        # Cloud Foundry.
+                        organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
+                        # SpaceGUID is the identifier for the project space within the
+                        # platform organization. This value is specific to Cloud Foundry.
+                        spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                      providerConfigRef:
+                        name: keyvalue-service-broker
                 providerConfigRef:
-                  name: keyvalue-service-broker
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
+                readiness:
+                  policy: DeriveFromObject
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.labels[crossplane.io/composite]
               - fromFieldPath: spec.service
-                toFieldPath: spec.forProvider.serviceName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.serviceName
               - fromFieldPath: spec.plan
-                toFieldPath: spec.forProvider.planName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.planName
               - fromFieldPath: spec.acceptsIncomplete
-                toFieldPath: spec.forProvider.acceptsIncomplete
-
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.acceptsIncomplete
               - fromFieldPath: spec.parameters.snapshot
-                toFieldPath: spec.forProvider.parameters.snapshot
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.snapshot
               - fromFieldPath: spec.parameters.replBacklogSize
-                toFieldPath: spec.forProvider.parameters.repl-backlog-size
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.repl-backlog-size
               - fromFieldPath: spec.parameters.minReplicasToWrite
-                toFieldPath: spec.forProvider.parameters.min-replicas-to-write
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.min-replicas-to-write
               - fromFieldPath: spec.parameters.minReplicasMaxLag
-                toFieldPath: spec.forProvider.parameters.min-replicas-max-lag
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.min-replicas-max-lag
               - fromFieldPath: spec.parameters.lazyfreeLazyEviction
-                toFieldPath: spec.forProvider.parameters.lazyfree-lazy-eviction
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.lazyfree-lazy-eviction
               - fromFieldPath: spec.parameters.lazyfreeLazyExpire
-                toFieldPath: spec.forProvider.parameters.lazyfree-lazy-expire
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.lazyfree-lazy-expire
               - fromFieldPath: spec.parameters.maxmemory
-                toFieldPath: spec.forProvider.parameters.maxmemory
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.maxmemory
               - fromFieldPath: spec.parameters.maxmemoryPolicy
-                toFieldPath: spec.forProvider.parameters.maxmemory-policy
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.maxmemory-policy
               - fromFieldPath: spec.parameters.maxmemorySamples
-                toFieldPath: spec.forProvider.parameters.maxmemory-samples
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.maxmemory-samples
               - fromFieldPath: spec.parameters.maxclients
-                toFieldPath: spec.forProvider.parameters.maxclients
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.maxclients
               - fromFieldPath: spec.parameters.downAfterMilliseconds
-                toFieldPath: spec.forProvider.parameters.down-after-milliseconds
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.down-after-milliseconds
               - fromFieldPath: spec.parameters.failoverTimeout
-                toFieldPath: spec.forProvider.parameters.failover-timeout
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.failover-timeout
               - fromFieldPath: spec.parameters.hostnameResolution
-                toFieldPath: spec.forProvider.parameters.hostname-resolution
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.hostname-resolution
               - fromFieldPath: spec.parameters.tlsProtocols
-                toFieldPath: spec.forProvider.parameters.tls-protocols
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.tls-protocols
               - fromFieldPath: spec.parameters.tlsCiphers
-                toFieldPath: spec.forProvider.parameters.tls-ciphers
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.tls-ciphers
               - fromFieldPath: spec.parameters.tlsCiphersuites
-                toFieldPath: spec.forProvider.parameters.tls-ciphersuites
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.tls-ciphersuites
               - fromFieldPath: spec.parameters.luaTimeLimit
-                toFieldPath: spec.forProvider.parameters.lua-time-limit
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.lua-time-limit
               - fromFieldPath: spec.parameters.notifyKeyspaceEvents
-                toFieldPath: spec.forProvider.parameters.notify-keyspace-events
-
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.notify-keyspace-events
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.createdAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.createdAt
                 toFieldPath: status.managed.createdAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.provisionedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.provisionedAt
                 toFieldPath: status.managed.provisionedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.state
+                fromFieldPath: status.atProvider.manifest.status.atProvider.state
                 toFieldPath: status.managed.state
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.updatedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.updatedAt
                 toFieldPath: status.managed.updatedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
+                policy:
+                  fromFieldPath: Optional

--- a/crossplane-api/api/a9s/logme2/composition.yaml
+++ b/crossplane-api/api/a9s/logme2/composition.yaml
@@ -15,79 +15,118 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real ServiceInstance (dataservices.anynines.com/v1 ServiceInstance)
+          # and its admin credentials are hosted in an "-internal" namespace whose
+          # name is derived by suffixing the synced namespace (the one shared
+          # between the app cluster and the control plane cluster) with
+          # "-internal". klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a9s-logme2
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: ServiceInstance
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-logme2
               spec:
                 forProvider:
-                  # acceptsIncomplete indicates if the service broker can fulfill a
-                  # request asynchronously. Since the anynines-provider controller
-                  # reconciles the resources asynchronously, if 'acceptsIncomplete' is
-                  # not specified by the user, it will default to 'true'.
-                  acceptsIncomplete: true
-                  # OrganizationGUID is the platform GUID for the organization under
-                  # which the service is to be provisioned. This value is specific to
-                  # Cloud Foundry.
-                  organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
-                  # SpaceGUID is the identifier for the project space within the
-                  # platform organization. This value is specific to Cloud Foundry.
-                  spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: ServiceInstance
+                    spec:
+                      forProvider:
+                        # acceptsIncomplete indicates if the service broker can fulfill a
+                        # request asynchronously. Since the anynines-provider controller
+                        # reconciles the resources asynchronously, if 'acceptsIncomplete' is
+                        # not specified by the user, it will default to 'true'.
+                        acceptsIncomplete: true
+                        # OrganizationGUID is the platform GUID for the organization under
+                        # which the service is to be provisioned. This value is specific to
+                        # Cloud Foundry.
+                        organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
+                        # SpaceGUID is the identifier for the project space within the
+                        # platform organization. This value is specific to Cloud Foundry.
+                        spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                      providerConfigRef:
+                        name: logme2-service-broker
                 providerConfigRef:
-                  name: logme2-service-broker
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
+                readiness:
+                  policy: DeriveFromObject                  
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.labels[crossplane.io/composite]
               - fromFieldPath: spec.service
-                toFieldPath: spec.forProvider.serviceName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.serviceName
               - fromFieldPath: spec.plan
-                toFieldPath: spec.forProvider.planName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.planName
               - fromFieldPath: spec.acceptsIncomplete
-                toFieldPath: spec.forProvider.acceptsIncomplete
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.acceptsIncomplete
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.createdAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.createdAt
                 toFieldPath: status.managed.createdAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.provisionedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.provisionedAt
                 toFieldPath: status.managed.provisionedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.state
+                fromFieldPath: status.atProvider.manifest.status.atProvider.state
                 toFieldPath: status.managed.state
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.updatedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.updatedAt
                 toFieldPath: status.managed.updatedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
-
+                policy:
+                  fromFieldPath: Optional
               # Custom parameters
               - fromFieldPath: spec.parameters.javaHeapspace
-                toFieldPath: spec.forProvider.parameters.java_heapspace
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.java_heapspace
               - fromFieldPath: spec.parameters.javaMaxmetaspace
-                toFieldPath: spec.forProvider.parameters.java_maxmetaspace
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.java_maxmetaspace
               - fromFieldPath: spec.parameters.javaGarbageCollector
-                toFieldPath: spec.forProvider.parameters.java_garbage_collector
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.java_garbage_collector
               - fromFieldPath: spec.parameters.ismJobInterval
-                toFieldPath: spec.forProvider.parameters.ism_job_interval
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.ism_job_interval
               - fromFieldPath: spec.parameters.ismDeletionAfter
-                toFieldPath: spec.forProvider.parameters.ism_deletion_after 
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.ism_deletion_after
               - fromFieldPath: spec.parameters.ismJitter
-                toFieldPath: spec.forProvider.parameters.ism_jitter
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.ism_jitter
               - fromFieldPath: spec.parameters.opensearchTlsProtocols
-                toFieldPath: spec.forProvider.parameters.opensearch-tls-protocols
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.opensearch-tls-protocols
               - fromFieldPath: spec.parameters.opensearchTlsCiphers
-                toFieldPath: spec.forProvider.parameters.opensearch-tls-ciphers
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.opensearch-tls-ciphers
               - fromFieldPath: spec.parameters.fluentdUdp
-                toFieldPath: spec.forProvider.parameters.fluentd-udp
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.fluentd-udp
               - fromFieldPath: spec.parameters.fluentdTcp
-                toFieldPath: spec.forProvider.parameters.fluentd-tcp
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.fluentd-tcp
               - fromFieldPath: spec.parameters.fluentdTls
-                toFieldPath: spec.forProvider.parameters.fluentd-tls
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.fluentd-tls
               - fromFieldPath: spec.parameters.fluentdTlsCiphers
-                toFieldPath: spec.forProvider.parameters.fluentd-tls-ciphers
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.fluentd-tls-ciphers
               - fromFieldPath: spec.parameters.fluentdTlsVersion
-                toFieldPath: spec.forProvider.parameters.fluentd-tls-version
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.fluentd-tls-version
               - fromFieldPath: spec.parameters.fluentdTlsMinVersion
-                toFieldPath: spec.forProvider.parameters.fluentd-tls-min-version
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.fluentd-tls-min-version
               - fromFieldPath: spec.parameters.fluentdTlsMaxVersion
-                toFieldPath: spec.forProvider.parameters.fluentd-tls-max-version
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.fluentd-tls-max-version
               - fromFieldPath: spec.parameters.groks
-                toFieldPath: spec.forProvider.parameters.groks
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.groks

--- a/crossplane-api/api/a9s/mariadb/composition.yaml
+++ b/crossplane-api/api/a9s/mariadb/composition.yaml
@@ -15,53 +15,92 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real ServiceInstance (dataservices.anynines.com/v1 ServiceInstance)
+          # and its admin credentials are hosted in an "-internal" namespace whose
+          # name is derived by suffixing the synced namespace (the one shared
+          # between the app cluster and the control plane cluster) with
+          # "-internal". klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a9s-mariadb
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: ServiceInstance
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-mariadb
               spec:
                 forProvider:
-                  # acceptsIncomplete indicates if the service broker can fulfill a
-                  # request asynchronously. Since the anynines-provider controller
-                  # reconciles the resources asynchronously, if 'acceptsIncomplete' is
-                  # not specified by the user, it will default to 'true'.
-                  acceptsIncomplete: true
-                  # OrganizationGUID is the platform GUID for the organization under
-                  # which the service is to be provisioned. This value is specific to
-                  # Cloud Foundry.
-                  organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
-                  # SpaceGUID is the identifier for the project space within the
-                  # platform organization. This value is specific to Cloud Foundry.
-                  spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: ServiceInstance
+                    spec:
+                      forProvider:
+                        # acceptsIncomplete indicates if the service broker can fulfill a
+                        # request asynchronously. Since the anynines-provider controller
+                        # reconciles the resources asynchronously, if 'acceptsIncomplete' is
+                        # not specified by the user, it will default to 'true'.
+                        acceptsIncomplete: true
+                        # OrganizationGUID is the platform GUID for the organization under
+                        # which the service is to be provisioned. This value is specific to
+                        # Cloud Foundry.
+                        organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
+                        # SpaceGUID is the identifier for the project space within the
+                        # platform organization. This value is specific to Cloud Foundry.
+                        spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                      providerConfigRef:
+                        name: mariadb-service-broker
                 providerConfigRef:
-                  name: mariadb-service-broker
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
+                readiness:
+                  policy: DeriveFromObject
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.labels[crossplane.io/composite]
               - fromFieldPath: spec.service
-                toFieldPath: spec.forProvider.serviceName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.serviceName
               - fromFieldPath: spec.plan
-                toFieldPath: spec.forProvider.planName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.planName
               - fromFieldPath: spec.acceptsIncomplete
-                toFieldPath: spec.forProvider.acceptsIncomplete
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.acceptsIncomplete
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.createdAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.createdAt
                 toFieldPath: status.managed.createdAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.provisionedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.provisionedAt
                 toFieldPath: status.managed.provisionedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.state
+                fromFieldPath: status.atProvider.manifest.status.atProvider.state
                 toFieldPath: status.managed.state
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.updatedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.updatedAt
                 toFieldPath: status.managed.updatedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
-
+                policy:
+                  fromFieldPath: Optional
               # Custom parameters
               - fromFieldPath: spec.parameters.binlogExpireDays
-                toFieldPath: spec.forProvider.parameters.binlog_expire_days
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.binlog_expire_days
               - fromFieldPath: spec.parameters.databases
-                toFieldPath: spec.forProvider.parameters.databases
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.databases
               - fromFieldPath: spec.parameters.grantPerformanceSchemaPermissions
-                toFieldPath: spec.forProvider.parameters.grant_performance_schema_permissions
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.grant_performance_schema_permissions

--- a/crossplane-api/api/a9s/messaging/composition.yaml
+++ b/crossplane-api/api/a9s/messaging/composition.yaml
@@ -15,52 +15,91 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real ServiceInstance (dataservices.anynines.com/v1 ServiceInstance)
+          # and its admin credentials are hosted in an "-internal" namespace whose
+          # name is derived by suffixing the synced namespace (the one shared
+          # between the app cluster and the control plane cluster) with
+          # "-internal". klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a9s-messaging
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: ServiceInstance
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-messaging
               spec:
                 forProvider:
-                  # acceptsIncomplete indicates if the service broker can fulfill a
-                  # request asynchronously. Since the anynines-provider controller
-                  # reconciles the resources asynchronously, if 'acceptsIncomplete' is
-                  # not specified by the user, it will default to 'true'.
-                  acceptsIncomplete: true
-                  # OrganizationGUID is the platform GUID for the organization under
-                  # which the service is to be provisioned. This value is specific to
-                  # Cloud Foundry.
-                  organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
-                  # SpaceGUID is the identifier for the project space within the
-                  # platform organization. This value is specific to Cloud Foundry.
-                  spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: ServiceInstance
+                    spec:
+                      forProvider:
+                        # acceptsIncomplete indicates if the service broker can fulfill a
+                        # request asynchronously. Since the anynines-provider controller
+                        # reconciles the resources asynchronously, if 'acceptsIncomplete' is
+                        # not specified by the user, it will default to 'true'.
+                        acceptsIncomplete: true
+                        # OrganizationGUID is the platform GUID for the organization under
+                        # which the service is to be provisioned. This value is specific to
+                        # Cloud Foundry.
+                        organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
+                        # SpaceGUID is the identifier for the project space within the
+                        # platform organization. This value is specific to Cloud Foundry.
+                        spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                      providerConfigRef:
+                        name: messaging-service-broker
                 providerConfigRef:
-                  name: messaging-service-broker
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
+                readiness:
+                  policy: DeriveFromObject
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.labels[crossplane.io/composite]
               - fromFieldPath: spec.service
-                toFieldPath: spec.forProvider.serviceName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.serviceName
               - fromFieldPath: spec.plan
-                toFieldPath: spec.forProvider.planName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.planName
               - fromFieldPath: spec.acceptsIncomplete
-                toFieldPath: spec.forProvider.acceptsIncomplete
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.acceptsIncomplete
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.createdAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.createdAt
                 toFieldPath: status.managed.createdAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.provisionedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.provisionedAt
                 toFieldPath: status.managed.provisionedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.state
+                fromFieldPath: status.atProvider.manifest.status.atProvider.state
                 toFieldPath: status.managed.state
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.updatedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.updatedAt
                 toFieldPath: status.managed.updatedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
-
+                policy:
+                  fromFieldPath: Optional
               - fromFieldPath: spec.parameters.consumerTimeout
-                toFieldPath: spec.forProvider.parameters.consumer_timeout
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.consumer_timeout
               - fromFieldPath: spec.parameters.tlsProtocols
-                toFieldPath: spec.forProvider.parameters.tls-protocols
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.tls-protocols
               - fromFieldPath: spec.parameters.tlsCiphers
-                toFieldPath: spec.forProvider.parameters.tls-ciphers
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.tls-ciphers

--- a/crossplane-api/api/a9s/messaging/definition.yaml
+++ b/crossplane-api/api/a9s/messaging/definition.yaml
@@ -34,6 +34,9 @@ spec:
                 ]
             - services:
                 &messagingServices [
+                  "a9s-messaging310",
+                  "a9s-messaging312",
+                  "a9s-messaging313",
                   "a9s-messaging4",
                 ]
           properties:

--- a/crossplane-api/api/a9s/mongodb/composition.yaml
+++ b/crossplane-api/api/a9s/mongodb/composition.yaml
@@ -15,47 +15,87 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real ServiceInstance (dataservices.anynines.com/v1 ServiceInstance)
+          # and its admin credentials are hosted in an "-internal" namespace whose
+          # name is derived by suffixing the synced namespace (the one shared
+          # between the app cluster and the control plane cluster) with
+          # "-internal". klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a9s-mongodb
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: ServiceInstance
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-mongodb
               spec:
                 forProvider:
-                  # acceptsIncomplete indicates if the service broker can fulfill a
-                  # request asynchronously. Since the anynines-provider controller
-                  # reconciles the resources asynchronously, if 'acceptsIncomplete' is
-                  # not specified by the user, it will default to 'true'.
-                  acceptsIncomplete: true
-                  # OrganizationGUID is the platform GUID for the organization under
-                  # which the service is to be provisioned. This value is specific to
-                  # Cloud Foundry.
-                  organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
-                  # SpaceGUID is the identifier for the project space within the
-                  # platform organization. This value is specific to Cloud Foundry.
-                  spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: ServiceInstance
+                    spec:
+                      forProvider:
+                        # acceptsIncomplete indicates if the service broker can fulfill a
+                        # request asynchronously. Since the anynines-provider controller
+                        # reconciles the resources asynchronously, if 'acceptsIncomplete' is
+                        # not specified by the user, it will default to 'true'.
+                        acceptsIncomplete: true
+                        # OrganizationGUID is the platform GUID for the organization under
+                        # which the service is to be provisioned. This value is specific to
+                        # Cloud Foundry.
+                        organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
+                        # SpaceGUID is the identifier for the project space within the
+                        # platform organization. This value is specific to Cloud Foundry.
+                        spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                      providerConfigRef:
+                        name: mongodb-service-broker
                 providerConfigRef:
-                  name: mongodb-service-broker
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
+                readiness:
+                  policy: DeriveFromObject
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.labels[crossplane.io/composite]
               - fromFieldPath: spec.service
-                toFieldPath: spec.forProvider.serviceName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.serviceName
               - fromFieldPath: spec.plan
-                toFieldPath: spec.forProvider.planName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.planName
               - fromFieldPath: spec.acceptsIncomplete
-                toFieldPath: spec.forProvider.acceptsIncomplete
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.acceptsIncomplete
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.createdAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.createdAt
                 toFieldPath: status.managed.createdAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.provisionedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.provisionedAt
                 toFieldPath: status.managed.provisionedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.state
+                fromFieldPath: status.atProvider.manifest.status.atProvider.state
                 toFieldPath: status.managed.state
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.updatedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.updatedAt
                 toFieldPath: status.managed.updatedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
+                policy:
+                  fromFieldPath: Optional
               - fromFieldPath: spec.parameters.setClusterParameter.changeStreamOptions.preAndPostImages.expireAfterSeconds
-                toFieldPath: spec.forProvider.parameters.set_cluster_parameter.changeStreamOptions.preAndPostImages.expireAfterSeconds
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.set_cluster_parameter.changeStreamOptions.preAndPostImages.expireAfterSeconds

--- a/crossplane-api/api/a9s/postgresql/composition.yaml
+++ b/crossplane-api/api/a9s/postgresql/composition.yaml
@@ -15,89 +15,127 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real ServiceInstance (dataservices.anynines.com/v1 ServiceInstance)
+          # and its admin credentials are hosted in an "-internal" namespace whose
+          # name is derived by suffixing the synced namespace (the one shared
+          # between the app cluster and the control plane cluster) with
+          # "-internal". klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a9s-postgresql
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: ServiceInstance
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-postgresql
               spec:
                 forProvider:
-                  # acceptsIncomplete indicates if the service broker can fulfill a
-                  # request asynchronously. Since the anynines-provider controller
-                  # reconciles the resources asynchronously, if 'acceptsIncomplete' is
-                  # not specified by the user, it will default to 'true'.
-                  acceptsIncomplete: true
-                  # OrganizationGUID is the platform GUID for the organization under
-                  # which the service is to be provisioned. This value is specific to
-                  # Cloud Foundry.
-                  organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
-                  # SpaceGUID is the identifier for the project space within the
-                  # platform organization. This value is specific to Cloud Foundry.
-                  spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: ServiceInstance
+                    spec:
+                      forProvider:
+                        # acceptsIncomplete indicates if the service broker can fulfill a
+                        # request asynchronously. Since the anynines-provider controller
+                        # reconciles the resources asynchronously, if 'acceptsIncomplete' is
+                        # not specified by the user, it will default to 'true'.
+                        acceptsIncomplete: true
+                        # OrganizationGUID is the platform GUID for the organization under
+                        # which the service is to be provisioned. This value is specific to
+                        # Cloud Foundry.
+                        organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
+                        # SpaceGUID is the identifier for the project space within the
+                        # platform organization. This value is specific to Cloud Foundry.
+                        spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                      providerConfigRef:
+                        name: postgresql-service-broker
                 providerConfigRef:
-                  name: postgresql-service-broker
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
+                readiness:
+                  policy: DeriveFromObject
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.labels[crossplane.io/composite]
               - fromFieldPath: spec.service
-                toFieldPath: spec.forProvider.serviceName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.serviceName
               - fromFieldPath: spec.plan
-                toFieldPath: spec.forProvider.planName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.planName
               - fromFieldPath: spec.acceptsIncomplete
-                toFieldPath: spec.forProvider.acceptsIncomplete
-
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.acceptsIncomplete
               - fromFieldPath: spec.parameters.dataChecksums
-                toFieldPath: spec.forProvider.parameters.data_checksums
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.data_checksums
               - fromFieldPath: spec.parameters.maxConnections
-                toFieldPath: spec.forProvider.parameters.max_connections
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.max_connections
               - fromFieldPath: spec.parameters.effectiveCacheSize
-                toFieldPath: spec.forProvider.parameters.effective_cache_size
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.effective_cache_size
               - fromFieldPath: spec.parameters.workMem
-                toFieldPath: spec.forProvider.parameters.work_mem
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.work_mem
               - fromFieldPath: spec.parameters.maintenanceWorkMem
-                toFieldPath: spec.forProvider.parameters.maintenance_work_mem
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.maintenance_work_mem
               - fromFieldPath: spec.parameters.tempFileLimit
-                toFieldPath: spec.forProvider.parameters.temp_file_limit
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.temp_file_limit
               - fromFieldPath: spec.parameters.trackIoTiming
-                toFieldPath: spec.forProvider.parameters.track_io_timing
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.track_io_timing
               - fromFieldPath: spec.parameters.archiveTimeout
-                toFieldPath: spec.forProvider.parameters.archive_timeout
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.archive_timeout
               - fromFieldPath: spec.parameters.statementTimeout
-                toFieldPath: spec.forProvider.parameters.statement_timeout
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.statement_timeout
               - fromFieldPath: spec.parameters.idleInTransactionSessionTimeout
-                toFieldPath: spec.forProvider.parameters.idle_in_transaction_session_timeout
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.idle_in_transaction_session_timeout
               - fromFieldPath: spec.parameters.rolePrivileges
-                toFieldPath: spec.forProvider.parameters.role_privileges
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.role_privileges
               - fromFieldPath: spec.parameters.walLevelLogical
-                toFieldPath: spec.forProvider.parameters.wal_level_logical
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.wal_level_logical
               - fromFieldPath: spec.parameters.walWriterDelay
-                toFieldPath: spec.forProvider.parameters.wal_writer_delay
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.wal_writer_delay
               - fromFieldPath: spec.parameters.maxReplicationSlots
-                toFieldPath: spec.forProvider.parameters.max_replication_slots
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.max_replication_slots
               - fromFieldPath: spec.parameters.maxWalSenders
-                toFieldPath: spec.forProvider.parameters.max_wal_senders
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.max_wal_senders
               - fromFieldPath: spec.parameters.synchronousCommit
-                toFieldPath: spec.forProvider.parameters.synchronous_commit
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.synchronous_commit
               - fromFieldPath: spec.parameters.clientMinMessages
-                toFieldPath: spec.forProvider.parameters.client_min_messages
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.client_min_messages
               - fromFieldPath: spec.parameters.logMinMessages
-                toFieldPath: spec.forProvider.parameters.pg_log_min_messages
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.pg_log_min_messages
               - fromFieldPath: spec.parameters.logMinErrorStatement
-                toFieldPath: spec.forProvider.parameters.pg_log_min_error_statement
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.pg_log_min_error_statement
               - fromFieldPath: spec.parameters.logStatement
-                toFieldPath: spec.forProvider.parameters.log_statement
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.log_statement
               - fromFieldPath: spec.parameters.logErrorVerbosity
-                toFieldPath: spec.forProvider.parameters.log_error_verbosity
-
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.log_error_verbosity
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.createdAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.createdAt
                 toFieldPath: status.managed.createdAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.provisionedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.provisionedAt
                 toFieldPath: status.managed.provisionedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.state
+                fromFieldPath: status.atProvider.manifest.status.atProvider.state
                 toFieldPath: status.managed.state
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.updatedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.updatedAt
                 toFieldPath: status.managed.updatedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
+                policy:
+                  fromFieldPath: Optional

--- a/crossplane-api/api/a9s/prometheus/composition.yaml
+++ b/crossplane-api/api/a9s/prometheus/composition.yaml
@@ -15,49 +15,89 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real ServiceInstance (dataservices.anynines.com/v1 ServiceInstance)
+          # and its admin credentials are hosted in an "-internal" namespace whose
+          # name is derived by suffixing the synced namespace (the one shared
+          # between the app cluster and the control plane cluster) with
+          # "-internal". klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a9s-prometheus
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: ServiceInstance
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-prometheus
               spec:
                 forProvider:
-                  # acceptsIncomplete indicates if the service broker can fulfill a
-                  # request asynchronously. Since the anynines-provider controller
-                  # reconciles the resources asynchronously, if 'acceptsIncomplete' is
-                  # not specified by the user, it will default to 'true'.
-                  acceptsIncomplete: true
-                  # OrganizationGUID is the platform GUID for the organization under
-                  # which the service is to be provisioned. This value is specific to
-                  # Cloud Foundry.
-                  organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
-                  # SpaceGUID is the identifier for the project space within the
-                  # platform organization. This value is specific to Cloud Foundry.
-                  spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: ServiceInstance
+                    spec:
+                      forProvider:
+                        # acceptsIncomplete indicates if the service broker can fulfill a
+                        # request asynchronously. Since the anynines-provider controller
+                        # reconciles the resources asynchronously, if 'acceptsIncomplete' is
+                        # not specified by the user, it will default to 'true'.
+                        acceptsIncomplete: true
+                        # OrganizationGUID is the platform GUID for the organization under
+                        # which the service is to be provisioned. This value is specific to
+                        # Cloud Foundry.
+                        organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
+                        # SpaceGUID is the identifier for the project space within the
+                        # platform organization. This value is specific to Cloud Foundry.
+                        spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                      providerConfigRef:
+                        name: prometheus-service-broker
                 providerConfigRef:
-                  name: prometheus-service-broker
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
+                readiness:
+                  policy: DeriveFromObject                  
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.labels[crossplane.io/composite]
               - fromFieldPath: spec.service
-                toFieldPath: spec.forProvider.serviceName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.serviceName
               - fromFieldPath: spec.plan
-                toFieldPath: spec.forProvider.planName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.planName
               - fromFieldPath: spec.acceptsIncomplete
-                toFieldPath: spec.forProvider.acceptsIncomplete
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.acceptsIncomplete
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.createdAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.createdAt
                 toFieldPath: status.managed.createdAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.provisionedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.provisionedAt
                 toFieldPath: status.managed.provisionedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.state
+                fromFieldPath: status.atProvider.manifest.status.atProvider.state
                 toFieldPath: status.managed.state
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.updatedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.updatedAt
                 toFieldPath: status.managed.updatedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
+                policy:
+                  fromFieldPath: Optional
               - fromFieldPath: spec.parameters.mappingStrictMatch
-                toFieldPath: spec.forProvider.parameters.mapping_strict_match
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.mapping_strict_match
               - fromFieldPath: spec.parameters.scrapeConfigs
-                toFieldPath: spec.forProvider.parameters.scrape_configs
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.scrape_configs

--- a/crossplane-api/api/a9s/restore/composition.yaml
+++ b/crossplane-api/api/a9s/restore/composition.yaml
@@ -15,32 +15,72 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real Restore (dataservices.anynines.com/v1 Restore) is hosted in an
+          # "-internal" namespace whose name is derived by suffixing the synced
+          # namespace (the one shared between the app cluster and the control
+          # plane cluster) with "-internal", next to the Backup it references.
+          # klutch-bind's servicenamespace reconciler owns both namespaces'
+          # lifecycle end-to-end.
           - name: a9s-restore
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: Restore
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-restore
+              spec:
+                forProvider:
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: Restore
+                providerConfigRef:
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
+                readiness:
+                  policy: DeriveFromObject
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.labels[crossplane.io/composite]
               - fromFieldPath: spec.backupRef
-                toFieldPath: spec.forProvider.backupName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.backupName
               - fromFieldPath: spec.serviceInstanceType
-                toFieldPath: spec.providerConfigRef.name
+                toFieldPath: spec.forProvider.manifest.spec.providerConfigRef.name
                 transforms:
                   - type: string
                     string:
                       type: Format
                       fmt: "%s-backup-manager"
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.finishedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.finishedAt
                 toFieldPath: status.managed.finishedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.restoreId
+                fromFieldPath: status.atProvider.manifest.status.atProvider.restoreId
                 toFieldPath: status.managed.restoreId
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.state
+                fromFieldPath: status.atProvider.manifest.status.atProvider.state
                 toFieldPath: status.managed.state
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.triggeredAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.triggeredAt
                 toFieldPath: status.managed.triggeredAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
+                policy:
+                  fromFieldPath: Optional

--- a/crossplane-api/api/a9s/search/composition.yaml
+++ b/crossplane-api/api/a9s/search/composition.yaml
@@ -15,57 +15,96 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real ServiceInstance (dataservices.anynines.com/v1 ServiceInstance)
+          # and its admin credentials are hosted in an "-internal" namespace whose
+          # name is derived by suffixing the synced namespace (the one shared
+          # between the app cluster and the control plane cluster) with
+          # "-internal". klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a9s-search
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: ServiceInstance
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-search
               spec:
                 forProvider:
-                  # acceptsIncomplete indicates if the service broker can fulfill a
-                  # request asynchronously. Since the anynines-provider controller
-                  # reconciles the resources asynchronously, if 'acceptsIncomplete' is
-                  # not specified by the user, it will default to 'true'.
-                  acceptsIncomplete: true
-                  # OrganizationGUID is the platform GUID for the organization under
-                  # which the service is to be provisioned. This value is specific to
-                  # Cloud Foundry.
-                  organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
-                  # SpaceGUID is the identifier for the project space within the
-                  # platform organization. This value is specific to Cloud Foundry.
-                  spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: ServiceInstance
+                    spec:
+                      forProvider:
+                        # acceptsIncomplete indicates if the service broker can fulfill a
+                        # request asynchronously. Since the anynines-provider controller
+                        # reconciles the resources asynchronously, if 'acceptsIncomplete' is
+                        # not specified by the user, it will default to 'true'.
+                        acceptsIncomplete: true
+                        # OrganizationGUID is the platform GUID for the organization under
+                        # which the service is to be provisioned. This value is specific to
+                        # Cloud Foundry.
+                        organizationGuid: a1d46b5c-b639-4f43-85c7-e9a0e5f01f75
+                        # SpaceGUID is the identifier for the project space within the
+                        # platform organization. This value is specific to Cloud Foundry.
+                        spaceGuid: 1bf71cf3-9017-4846-bffc-b9b31872bfaf
+                      providerConfigRef:
+                        name: search-service-broker
                 providerConfigRef:
-                  name: search-service-broker
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
+                readiness:
+                  policy: DeriveFromObject
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.labels[crossplane.io/composite]
               - fromFieldPath: spec.service
-                toFieldPath: spec.forProvider.serviceName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.serviceName
               - fromFieldPath: spec.plan
-                toFieldPath: spec.forProvider.planName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.planName
               - fromFieldPath: spec.acceptsIncomplete
-                toFieldPath: spec.forProvider.acceptsIncomplete
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.acceptsIncomplete
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.createdAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.createdAt
                 toFieldPath: status.managed.createdAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.provisionedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.provisionedAt
                 toFieldPath: status.managed.provisionedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.state
+                fromFieldPath: status.atProvider.manifest.status.atProvider.state
                 toFieldPath: status.managed.state
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.updatedAt
+                fromFieldPath: status.atProvider.manifest.status.atProvider.updatedAt
                 toFieldPath: status.managed.updatedAt
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
-
+                policy:
+                  fromFieldPath: Optional
               # Custom parameters
               - fromFieldPath: spec.parameters.javaHeapspace
-                toFieldPath: spec.forProvider.parameters.java_heapspace
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.java_heapspace
               - fromFieldPath: spec.parameters.javaMaxmetaspace
-                toFieldPath: spec.forProvider.parameters.java_maxmetaspace
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.java_maxmetaspace
               - fromFieldPath: spec.parameters.javaGarbageCollector
-                toFieldPath: spec.forProvider.parameters.java_garbage_collector
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.java_garbage_collector
               - fromFieldPath: spec.parameters.tlsProtocols
-                toFieldPath: spec.forProvider.parameters.tls-protocols
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.tls-protocols
               - fromFieldPath: spec.parameters.tlsCiphers
-                toFieldPath: spec.forProvider.parameters.tls-ciphers
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.parameters.tls-ciphers

--- a/crossplane-api/api/a9s/servicebinding/composition.yaml
+++ b/crossplane-api/api/a9s/servicebinding/composition.yaml
@@ -15,44 +15,164 @@ spec:
         apiVersion: pt.fn.crossplane.io/v1beta1
         kind: Resources
         resources:
+          # The real ServiceBinding (dataservices.anynines.com/v1 ServiceBinding)
+          # and its raw relay credentials are hosted in an "-internal" namespace
+          # whose name is derived by suffixing the synced namespace (the one shared
+          # between the app cluster and the control plane cluster) with
+          # "-internal". klutch-bind's servicenamespace reconciler owns both
+          # namespaces' lifecycle end-to-end.
           - name: a9s-servicebinding
             base:
-              apiVersion: dataservices.anynines.com/v1
-              kind: ServiceBinding
+              apiVersion: kubernetes.m.crossplane.io/v1alpha1
+              kind: Object
+              metadata:
+                labels:
+                  klutch.anynines.com/composition-resource: a9s-servicebinding
               spec:
                 forProvider:
-                  # acceptsIncomplete indicates if the service broker can fulfill a
-                  # request asynchronously. Since the anynines-provider controller
-                  # reconciles the resources asynchronously, if 'acceptsIncomplete' is
-                  # not specified by the user, it will default to 'true'.
-                  acceptsIncomplete: true
+                  manifest:
+                    apiVersion: dataservices.anynines.com/v1
+                    kind: ServiceBinding
+                    spec:
+                      forProvider:
+                        # acceptsIncomplete indicates if the service broker can fulfill a
+                        # request asynchronously. Since the anynines-provider controller
+                        # reconciles the resources asynchronously, if 'acceptsIncomplete' is
+                        # not specified by the user, it will default to 'true'.
+                        acceptsIncomplete: true
+                providerConfigRef:
+                  name: kubernetes-provider
+                  kind: ClusterProviderConfig
             patches:
+              - fromFieldPath: metadata.namespace
+                toFieldPath: spec.forProvider.manifest.metadata.namespace
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.metadata.name
               - fromFieldPath: spec.serviceInstanceType
-                toFieldPath: metadata.labels[klutch.io/instance-type]
+                toFieldPath: spec.forProvider.manifest.metadata.labels[klutch.io/instance-type]
               - fromFieldPath: spec.instanceRef
-                toFieldPath: spec.forProvider.instanceName
+                toFieldPath: spec.forProvider.manifest.spec.forProvider.instanceName
               - fromFieldPath: spec.serviceInstanceType
-                toFieldPath: spec.providerConfigRef.name
+                toFieldPath: spec.forProvider.manifest.spec.providerConfigRef.name
                 transforms:
                   - type: string
                     string:
                       type: Format
                       fmt: "%s-service-broker"
+              # Raw relay Secret written by provider-anynines into -internal. Name is
+              # fixed as <name>-creds-raw; the developer-facing Secret is produced by
+              # the create-connection-secret pipeline step using dig-based naming.
               - fromFieldPath: metadata.namespace
-                toFieldPath: spec.writeConnectionSecretToRef.namespace
-              - fromFieldPath: metadata.name
-                toFieldPath: spec.writeConnectionSecretToRef.name
+                toFieldPath: spec.forProvider.manifest.spec.writeConnectionSecretToRef.namespace
                 transforms:
                   - type: string
                     string:
                       type: Format
-                      fmt: "%s-creds"
+                      fmt: "%s-internal"
+              - fromFieldPath: metadata.name
+                toFieldPath: spec.forProvider.manifest.spec.writeConnectionSecretToRef.name
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-creds-raw"
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.serviceBindingID
+                fromFieldPath: status.atProvider.manifest.status.atProvider.serviceBindingID
                 toFieldPath: status.managed.serviceBindingID
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.atProvider.state
+                fromFieldPath: status.atProvider.manifest.status.atProvider.state
                 toFieldPath: status.managed.state
+                policy:
+                  fromFieldPath: Optional
               - type: ToCompositeFieldPath
-                fromFieldPath: status.conditions
+                fromFieldPath: status.atProvider.manifest.status.conditions
                 toFieldPath: status.managed.conditions
+                policy:
+                  fromFieldPath: Optional
+    # Requests the provider-written credentials Secret (<binding-name>-creds-raw)
+    # from the -internal namespace via function-go-templating's built-in ExtraResources
+    # requirement, so the create-connection-secret step can forward all fields
+    # without a relay object ever existing outside the -internal namespace.
+    - step: request-credentials-secret
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            {{- $xr := $.observed.composite.resource }}
+            apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+            kind: ExtraResources
+            requirements:
+              credentials-secret:
+                apiVersion: v1
+                kind: Secret
+                matchName: {{ printf "%s-creds-raw" $xr.metadata.name }}
+                namespace: {{ printf "%s-internal" $xr.metadata.namespace }}
+    # Creates the final developer-facing connection Secret in the XR namespace.
+    # Default name is <binding-name>-creds; the user may override via
+    # spec.writeConnectionSecretToRef.name. Only fields on the per-type allowlist
+    # are forwarded from the raw Secret, so unexpected broker fields never leak through.
+    - step: create-connection-secret
+      functionRef:
+        name: function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            {{- $xr := $.observed.composite.resource }}
+            {{- $extraRes := index $.context "apiextensions.crossplane.io/extra-resources" | default dict }}
+            {{- $credEntry := index $extraRes "credentials-secret" | default dict }}
+            {{- $credItems := index $credEntry "items" | default (list) }}
+            {{- $credData := dict }}
+            {{- if gt (len $credItems) 0 }}
+            {{- $credData = (index $credItems 0).resource.data | default dict }}
+            {{- end }}
+            {{- $hasCredentials := gt (len $credItems) 0 }}
+            {{- if $hasCredentials }}
+            {{- $secretName := dig "spec" "writeConnectionSecretToRef" "name" (printf "%s-creds" $xr.metadata.name) $xr }}
+            {{- /* Per-type key allowlist so unexpected broker response fields are never forwarded. */}}
+            {{- $allowLists := dict
+                "postgresql" (dict "host" true "hosts" true "name" true "password" true "port" true "uri" true "username" true)
+                "mariadb" (dict "cacrt" true "host" true "hosts" true "name" true "password" true "port" true "uri" true "username" true)
+                "mongodb" (dict "default_database" true "hosts" true "password" true "uri" true "username" true)
+                "keyvalue" (dict "cacrt" true "host" true "hosts" true "load_balanced_host" true "valkey.password" true "valkey.port" true "valkey.username" true)
+                "search" (dict "cacrt" true "host" true "hosts" true "password" true "port" true "scheme" true "username" true)
+                "logme2" (dict "cacrt" true "host" true "password" true "syslog_drain_url" true "username" true)
+                "prometheus" (dict "alertmanager_urls" true "grafana_urls" true "graphite_exporter_port" true "graphite_exporters" true "password" true "prometheus_urls" true "username" true)
+                "messaging" (dict
+                  "http_api_uri" true "http_api_uris" true
+                  "protocols.amqp_ssl.host" true "protocols.amqp_ssl.hosts" true "protocols.amqp_ssl.password" true
+                  "protocols.amqp_ssl.port" true "protocols.amqp_ssl.ssl" true "protocols.amqp_ssl.uri" true "protocols.amqp_ssl.username" true
+                  "protocols.management.cacrt" true "protocols.management.host" true "protocols.management.hosts" true
+                  "protocols.management.password" true "protocols.management.path" true "protocols.management.port" true
+                  "protocols.management.ssl" true "protocols.management.uri" true "protocols.management.uris" true "protocols.management.username" true)
+            }}
+            {{- $allowedKeys := index $allowLists $xr.spec.serviceInstanceType | default dict }}
+            apiVersion: v1
+            kind: Secret
+            metadata:
+              name: {{ $secretName | quote }}
+              namespace: {{ $xr.metadata.namespace | quote }}
+              annotations:
+                {{ setResourceNameAnnotation "connection-secret" }}
+                gotemplating.fn.crossplane.io/ready: "True"
+            type: connection.crossplane.io/v1alpha1
+            data:
+              {{- range $k, $v := $credData }}
+              {{- if hasKey $allowedKeys $k }}
+              {{ $k }}: {{ $v }}
+              {{- end }}
+              {{- end }}
+            {{- end }}

--- a/crossplane-api/api/common/servicebinding_definition.yaml
+++ b/crossplane-api/api/common/servicebinding_definition.yaml
@@ -32,7 +32,9 @@ spec:
           properties:
             spec:
               x-kubernetes-validations:
-                # Validation for crossplane.compositionRef and serviceInstanceType combination.
+                # Prevents non-postgresql service types from silently using the default composition
+                # (a8s-servicebinding), which only supports postgresql. Non-postgresql bindings must
+                # explicitly set crossplane.compositionRef.name to an appropriate composition.
                 - rule: "((has(self.crossplane) && has(self.crossplane.compositionRef) && has(self.crossplane.compositionRef.name) &&
                     self.crossplane.compositionRef.name != '' &&
                     self.crossplane.compositionRef.name != 'a8s-servicebinding') ||
@@ -48,13 +50,13 @@ spec:
                     Optional. Controls the name of the Secret written to the ServiceBinding's namespace
                     containing connection credentials. If set, the value of `name` is used as the Secret
                     name. If omitted, the composition falls back to a default name of the form
-                    `{servicebinding-name}-pg-creds`.
+                    `{servicebinding-name}-creds`.
                   type: object
                   properties:
                     name:
                       description: >-
                         Name of the Secret to write connection credentials into. If not specified,
-                        the composition defaults to `{servicebinding-name}-pg-creds`.
+                        the composition defaults to `{servicebinding-name}-creds`.
                       type: string
                   required:
                     - name

--- a/crossplane-api/deploy/config-pkg-anynines.yaml
+++ b/crossplane-api/deploy/config-pkg-anynines.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: anynines-dataservices
 spec:
-  package: public.ecr.aws/h6x7g6i7/klutch/dataservices:KLT-877
+  package: public.ecr.aws/h6x7g6i7/klutch/dataservices:KLT-1022-v2

--- a/crossplane-api/deploy/functions/function-go-templating.yaml
+++ b/crossplane-api/deploy/functions/function-go-templating.yaml
@@ -3,4 +3,4 @@ kind: Function
 metadata:
   name: function-go-templating
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.9.2
+  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.3

--- a/crossplane-api/deploy/provider-anynines.yaml
+++ b/crossplane-api/deploy/provider-anynines.yaml
@@ -3,7 +3,7 @@ kind: Provider
 metadata:
   name: provider-anynines
 spec:
-  package: "public.ecr.aws/h6x7g6i7/klutch/provider-anynines:KLT-877"
+  package: "public.ecr.aws/w5n9a2g2/klutch/provider-anynines:KLT-1022-v2"
   runtimeConfigRef:
     name: provider-anynines
 ---
@@ -19,6 +19,7 @@ spec:
         spec:
           containers:
             - name: package-runtime
+              image: public.ecr.aws/w5n9a2g2/klutch/provider-anynines-controller:KLT-1022-v2
               # Enable health checks
               readinessProbe:
                 httpGet:

--- a/crossplane-api/examples/a9s/keyvalue/backup.yaml
+++ b/crossplane-api/examples/a9s/keyvalue/backup.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-keyvalue
   namespace: default
 spec:
+  instanceRef: example-a9s-keyvalue
+  serviceInstanceType: keyvalue
   crossplane:
     compositionRef:
       name: a9s-backup
-  instanceRef: example-a9s-keyvalue
-  serviceInstanceType: keyvalue

--- a/crossplane-api/examples/a9s/keyvalue/restore.yaml
+++ b/crossplane-api/examples/a9s/keyvalue/restore.yaml
@@ -3,8 +3,8 @@ kind: Restore
 metadata:
   name: example-a9s-keyvalue
 spec:
+  backupRef: example-a9s-keyvalue
+  serviceInstanceType: keyvalue
   crossplane:
     compositionRef:
       name: a9s-restore
-    backupRef: example-a9s-keyvalue
-    serviceInstanceType: keyvalue

--- a/crossplane-api/examples/a9s/keyvalue/servicebinding.yaml
+++ b/crossplane-api/examples/a9s/keyvalue/servicebinding.yaml
@@ -4,9 +4,12 @@ metadata:
   name: example-a9s-keyvalue
   namespace: default
 spec:
-  crossplane:
-    compositionRef:
-      name: a9s-servicebinding
   # instanceRef indicates the name of the DataServiceInstance
   instanceRef: example-a9s-keyvalue
   serviceInstanceType: keyvalue # Adjust for each Service Instance type
+  #Optional
+  #writeConnectionSecretToRef:
+  #  name: example-a9s-keyvalue-creds
+  crossplane:
+    compositionRef:
+      name: a9s-servicebinding

--- a/crossplane-api/examples/a9s/logme2/backup.yaml
+++ b/crossplane-api/examples/a9s/logme2/backup.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-logme2
   namespace: default
 spec:
+  instanceRef: example-a9s-logme2
+  serviceInstanceType: logme2
   crossplane:
     compositionRef:
       name: a9s-backup
-  instanceRef: example-a9s-logme2
-  serviceInstanceType: logme2

--- a/crossplane-api/examples/a9s/logme2/restore.yaml
+++ b/crossplane-api/examples/a9s/logme2/restore.yaml
@@ -3,8 +3,8 @@ kind: Restore
 metadata:
   name: example-a9s-logme2
 spec:
+  backupRef: example-a9s-logme2
+  serviceInstanceType: logme2
   crossplane:
     compositionRef:
       name: a9s-restore
-    backupRef: example-a9s-logme2
-    serviceInstanceType: logme2

--- a/crossplane-api/examples/a9s/logme2/servicebinding.yaml
+++ b/crossplane-api/examples/a9s/logme2/servicebinding.yaml
@@ -4,9 +4,12 @@ metadata:
   name: example-a9s-logme2
   namespace: default
 spec:
-  crossplane:
-    compositionRef:
-      name: a9s-servicebinding
   # instanceName indicates the name of the DataServiceInstance
   instanceRef: example-a9s-logme2
   serviceInstanceType: logme2 # Adjust for each Service Instance type
+  #Optional
+  #writeConnectionSecretToRef:
+  #  name: example-a9s-logme2-creds
+  crossplane:
+    compositionRef:
+      name: a9s-servicebinding

--- a/crossplane-api/examples/a9s/mariadb/backup.yaml
+++ b/crossplane-api/examples/a9s/mariadb/backup.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-mariadb
   namespace: default
 spec:
+  instanceRef: example-a9s-mariadb
+  serviceInstanceType: mariadb
   crossplane:
     compositionRef:
       name: a9s-backup
-  instanceRef: example-a9s-mariadb
-  serviceInstanceType: mariadb

--- a/crossplane-api/examples/a9s/mariadb/restore.yaml
+++ b/crossplane-api/examples/a9s/mariadb/restore.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-mariadb
   namespace: default
 spec:
+  backupRef: example-a9s-mariadb
+  serviceInstanceType: mariadb
   crossplane:
     compositionRef:
       name: a9s-restore
-    backupRef: example-a9s-mariadb
-    serviceInstanceType: mariadb

--- a/crossplane-api/examples/a9s/mariadb/servicebinding.yaml
+++ b/crossplane-api/examples/a9s/mariadb/servicebinding.yaml
@@ -4,9 +4,12 @@ metadata:
   name: example-a9s-mariadb
   namespace: default
 spec:
-  crossplane:
-    compositionRef:
-      name: a9s-servicebinding
   # instanceRef indicates the name of the DataServiceInstance
   instanceRef: example-a9s-mariadb
   serviceInstanceType: mariadb # Adjust for each Service Instance type
+  #Optional
+  #writeConnectionSecretToRef:
+  #  name: example-a9s-mariadb-creds
+  crossplane:
+    compositionRef:
+      name: a9s-servicebinding

--- a/crossplane-api/examples/a9s/messaging/backup.yaml
+++ b/crossplane-api/examples/a9s/messaging/backup.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-messaging
   namespace: default
 spec:
+  instanceRef: example-a9s-messaging
+  serviceInstanceType: messaging
   crossplane:
     compositionRef:
       name: a9s-backup
-  instanceRef: example-a9s-messaging
-  serviceInstanceType: messaging

--- a/crossplane-api/examples/a9s/messaging/restore.yaml
+++ b/crossplane-api/examples/a9s/messaging/restore.yaml
@@ -3,8 +3,8 @@ kind: Restore
 metadata:
   name: example-a9s-messaging
 spec:
+  backupRef: example-a9s-messaging
+  serviceInstanceType: messaging
   crossplane:
     compositionRef:
       name: a9s-restore
-    backupRef: example-a9s-messaging
-    serviceInstanceType: messaging

--- a/crossplane-api/examples/a9s/messaging/servicebinding.yaml
+++ b/crossplane-api/examples/a9s/messaging/servicebinding.yaml
@@ -4,9 +4,12 @@ metadata:
   name: example-a9s-messaging
   namespace: default
 spec:
-  crossplane:
-    compositionRef:
-      name: a9s-servicebinding
   # instanceName indicates the name of the DataServiceInstance
   instanceRef: example-a9s-messaging
   serviceInstanceType: messaging # Adjust for each Service Instance type
+  #Optional
+  #writeConnectionSecretToRef:
+  #  name: example-a9s-messaging-creds
+  crossplane:
+    compositionRef:
+      name: a9s-servicebinding

--- a/crossplane-api/examples/a9s/mongodb/backup.yaml
+++ b/crossplane-api/examples/a9s/mongodb/backup.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-mongodb
   namespace: default
 spec:
+  instanceRef: example-a9s-mongodb
+  serviceInstanceType: mongodb
   crossplane:
     compositionRef:
       name: a9s-backup
-  instanceRef: example-a9s-mongodb
-  serviceInstanceType: mongodb

--- a/crossplane-api/examples/a9s/mongodb/restore.yaml
+++ b/crossplane-api/examples/a9s/mongodb/restore.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-mongodb
   namespace: default  
 spec:
+  backupRef: example-a9s-mongodb
+  serviceInstanceType: mongodb
   crossplane:
     compositionRef:
       name: a9s-restore
-    backupRef: example-a9s-mongodb
-    serviceInstanceType: mongodb

--- a/crossplane-api/examples/a9s/mongodb/servicebinding.yaml
+++ b/crossplane-api/examples/a9s/mongodb/servicebinding.yaml
@@ -4,9 +4,12 @@ metadata:
   name: example-a9s-mongodb
   namespace: default
 spec:
-  crossplane:
-    compositionRef:
-      name: a9s-servicebinding
   # instanceName indicates the name of the DataServiceInstance
   instanceRef: example-a9s-mongodb
   serviceInstanceType: mongodb # Adjust for each Service Instance type
+  #Optional
+  #writeConnectionSecretToRef:
+  #  name: example-a9s-mongodb-creds
+  crossplane:
+    compositionRef:
+      name: a9s-servicebinding

--- a/crossplane-api/examples/a9s/postgresql/backup.yaml
+++ b/crossplane-api/examples/a9s/postgresql/backup.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-postgresql
   namespace: default
 spec:
+  instanceRef: example-a9s-postgresql
+  serviceInstanceType: postgresql
   crossplane:
     compositionRef:
       name: a9s-backup
-  instanceRef: example-a9s-postgresql
-  serviceInstanceType: postgresql

--- a/crossplane-api/examples/a9s/postgresql/restore.yaml
+++ b/crossplane-api/examples/a9s/postgresql/restore.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-postgresql
   namespace: default  
 spec:
+  backupRef: example-a9s-postgresql
+  serviceInstanceType: postgresql
   crossplane:
     compositionRef:
       name: a9s-restore
-  backupRef: example-a9s-postgresql
-  serviceInstanceType: postgresql

--- a/crossplane-api/examples/a9s/postgresql/servicebinding.yaml
+++ b/crossplane-api/examples/a9s/postgresql/servicebinding.yaml
@@ -7,6 +7,9 @@ spec:
   # instanceRef indicates the name of the DataServiceInstance
   instanceRef: example-a9s-postgresql
   serviceInstanceType: postgresql # Adjust for each Service Instance type
+  #Optional
+  #writeConnectionSecretToRef:
+  #  name: example-a9s-postgresql-creds
   crossplane:
     compositionRef:
       name: a9s-servicebinding

--- a/crossplane-api/examples/a9s/prometheus/backup.yaml
+++ b/crossplane-api/examples/a9s/prometheus/backup.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-prometheus
   namespace: default
 spec:
+  instanceRef: example-a9s-prometheus
+  serviceInstanceType: prometheus
   crossplane:
     compositionRef:
       name: a9s-backup
-  instanceRef: example-a9s-prometheus
-  serviceInstanceType: prometheus

--- a/crossplane-api/examples/a9s/prometheus/restore.yaml
+++ b/crossplane-api/examples/a9s/prometheus/restore.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-prometheus
   namespace: default  
 spec:
+  backupRef: example-a9s-prometheus
+  serviceInstanceType: prometheus
   crossplane:
     compositionRef:
       name: a9s-restore
-    backupRef: example-a9s-prometheus
-    serviceInstanceType: prometheus

--- a/crossplane-api/examples/a9s/prometheus/servicebinding.yaml
+++ b/crossplane-api/examples/a9s/prometheus/servicebinding.yaml
@@ -4,9 +4,12 @@ metadata:
   name: example-a9s-prometheus
   namespace: default
 spec:
-  crossplane:
-    compositionRef:
-      name: a9s-servicebinding
   # instanceRef indicates the name of the DataServiceInstance
   instanceRef: example-a9s-prometheus
   serviceInstanceType: prometheus # Adjust for each Service Instance type
+  #Optional
+  #writeConnectionSecretToRef:
+  #  name: example-a9s-prometheus-creds
+  crossplane:
+    compositionRef:
+      name: a9s-servicebinding

--- a/crossplane-api/examples/a9s/search/backup.yaml
+++ b/crossplane-api/examples/a9s/search/backup.yaml
@@ -4,8 +4,8 @@ metadata:
   name: example-a9s-search
   namespace: default
 spec:
+  instanceRef: example-a9s-search
+  serviceInstanceType: search
   crossplane:
     compositionRef:
       name: a9s-backup
-  instanceRef: example-a9s-search
-  serviceInstanceType: search

--- a/crossplane-api/examples/a9s/search/restore.yaml
+++ b/crossplane-api/examples/a9s/search/restore.yaml
@@ -3,8 +3,8 @@ kind: Restore
 metadata:
   name: example-a9s-search
 spec:
+  backupRef: example-a9s-search
+  serviceInstanceType: search
   crossplane:
     compositionRef:
       name: a9s-restore
-    backupRef: example-a9s-search
-    serviceInstanceType: search

--- a/crossplane-api/examples/a9s/search/servicebinding.yaml
+++ b/crossplane-api/examples/a9s/search/servicebinding.yaml
@@ -4,9 +4,12 @@ metadata:
   name: example-a9s-search
   namespace: default
 spec:
-  crossplane:
-    compositionRef:
-      name: a9s-servicebinding
   # instanceRef indicates the name of the DataServiceInstance
   instanceRef: example-a9s-search
   serviceInstanceType: search # Adjust for each Service Instance type
+  #Optional
+  #writeConnectionSecretToRef:
+  #  name: example-a9s-search-creds
+  crossplane:
+    compositionRef:
+      name: a9s-servicebinding

--- a/provider-anynines/.golangci.yml
+++ b/provider-anynines/.golangci.yml
@@ -1,0 +1,124 @@
+version: "2"
+output:
+  formats:
+    text:
+      path: stdout
+linters:
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - goconst
+    - gocritic
+    - gocyclo
+    - gosec
+    - gosmopolitan
+    - loggercheck
+    - makezero
+    - misspell
+    - nakedret
+    - nilerr
+    - nilnesserr
+    - noctx
+    - prealloc
+    - protogetter
+    - reassign
+    - recvcheck
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - testifylint
+    - unconvert
+    - unparam
+    - whitespace
+    - zerologlint
+  disable:
+    - musttag
+  settings:
+    dupl:
+      threshold: 100
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+    goconst:
+      min-len: 3
+      min-occurrences: 5
+    gocritic:
+      enabled-tags:
+        - performance
+      settings:
+        captLocal:
+          paramsOnly: true
+        rangeValCopy:
+          sizeThreshold: 32
+    gocyclo:
+      min-complexity: 10
+    lll:
+      tab-width: 1
+    nakedret:
+      max-func-lines: 30
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: false
+    unparam:
+      check-exported: false
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - exportloopref
+          - goconst
+          - gocyclo
+          - gosec
+          - unparam
+        path: _test(ing)?\.go
+      - linters:
+          - gocritic
+        path: _test\.go
+        text: (unnamedResult|exitAfterDefer)
+      - linters:
+          - gocritic
+        text: '(hugeParam|rangeValCopy):'
+      - linters:
+          - staticcheck
+        text: 'SA3000:'
+      - linters:
+          - gosec
+        text: 'G101:'
+      - linters:
+          - gosec
+        text: 'G104:'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-same-issues: 0
+  new: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/crossplane/provider-template
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/provider-anynines/Makefile
+++ b/provider-anynines/Makefile
@@ -25,7 +25,7 @@ GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal apis pkg
 GO111MODULE = on
-GOLANGCILINT_VERSION := 1.64.8
+GOLANGCILINT_VERSION := 2.12.2
 -include build/makelib/golang.mk
 
 # kind-related versions
@@ -239,7 +239,7 @@ provider-build-push:
 	cp package/crossplane.yaml bu.yaml
 	cat package/crossplane.yaml | sed "s/\VERSION/$(IMAGETAG)/g" > package/temp_crossplane.yaml
 	mv package/temp_crossplane.yaml package/crossplane.yaml
-	crossplane xpkg build --package-file package/$(PROJECT_NAME).xpkg --package-root package
+	crossplane xpkg build --package-file package/$(PROJECT_NAME).xpkg --package-root package --embed-runtime-image $(ECR_REPO)/$(PROJECT_NAME)-controller:$(IMAGETAG)
 	$(INFO) "Building provider image"
 	crossplane xpkg push --package-files package/$(PROJECT_NAME).xpkg $(ECR_REPO)/$(PROJECT_NAME):$(IMAGETAG)
 	$(INFO) "image $(PROJECT_NAME):$(IMAGETAG) pushed to ECR"

--- a/provider-anynines/apis/serviceinstance/v1/serviceinstance_types.go
+++ b/provider-anynines/apis/serviceinstance/v1/serviceinstance_types.go
@@ -210,25 +210,35 @@ func (p *ServiceInstance) GetServiceID() (string, error) {
 }
 
 func (list *ServiceInstanceList) ToServiceInstance(name string) (*ServiceInstance, error) {
-	var err (error)
 	switch {
-	case len(list.Items) > 1:
-		err = fmt.Errorf(
-			"%s, expected 1 ServiceInstance managed resource for %s, but got %d",
-			errGetServiceInstance,
-			name,
-			len(list.Items),
-		)
 	case len(list.Items) == 0:
-		err = fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%s, failed to list ServiceInstance managed resources for %s: %w",
 			errGetServiceInstance,
 			name,
 			ErrServiceInstanceNotFound,
 		)
-	default:
+	case len(list.Items) == 1:
 		return &list.Items[0], nil
+	default:
+		// Multiple ServiceInstances share the same composite label (e.g. during
+		// a plan upgrade Crossplane creates the new composed MR before removing
+		// the old one). Filter to non-deleting items to find the active one.
+		var active []*ServiceInstance
+		for i := range list.Items {
+			si := &list.Items[i]
+			if si.DeletionTimestamp == nil {
+				active = append(active, si)
+			}
+		}
+		if len(active) == 1 {
+			return active[0], nil
+		}
+		return nil, fmt.Errorf(
+			"%s, expected 1 ServiceInstance managed resource for %s, but got %d",
+			errGetServiceInstance,
+			name,
+			len(list.Items),
+		)
 	}
-
-	return nil, err
 }

--- a/provider-anynines/examples/provider/provider.yaml
+++ b/provider-anynines/examples/provider/provider.yaml
@@ -3,4 +3,4 @@ kind: Provider
 metadata:
   name: provider-anynines
 spec:
-  package: "public.ecr.aws/h6x7g6i7/klutch/provider-anynines:KLT-877"
+  package: "public.ecr.aws/w5n9a2g2/klutch/provider-anynines:KLT-1022-v2"

--- a/provider-anynines/internal/controller/backup/backup.go
+++ b/provider-anynines/internal/controller/backup/backup.go
@@ -375,12 +375,11 @@ func (c *External) Disconnect(ctx context.Context) error {
 	return nil
 }
 
-func (c External) GetServiceInstanceManagedResource(ctx context.Context, bkp v1.Backup) (*dsv1.ServiceInstance, error) {
-	// Get Service Instance Managed Resource
-	instances := &dsv1.ServiceInstanceList{}
-
+func (c *External) GetServiceInstanceManagedResource(ctx context.Context, bkp v1.Backup) (*dsv1.ServiceInstance, error) {
 	// In Crossplane v2 (Namespaced XRs), composed MRs carry the label
-	// crossplane.io/composite: <xr-name> instead of the v1 claim labels.
+	// crossplane.io/composite: <xr-name> instead of the v1 claim labels. The
+	// Backup and ServiceInstance MRs are composed into the same "-internal"
+	// namespace, so no cross-namespace lookup is needed here.
 	labelSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			constants.LabelKeyComposite: bkp.Spec.ForProvider.InstanceName,
@@ -388,13 +387,13 @@ func (c External) GetServiceInstanceManagedResource(ctx context.Context, bkp v1.
 	})
 	if err != nil {
 		return nil, fmt.Errorf(
-			"%s, failed to create label selector for "+
-				"ServiceInstance managed resources: %w",
+			"%s, failed to create label selector for ServiceInstance managed resources: %w",
 			errNewBackup,
 			err,
 		)
 	}
 
+	instances := &dsv1.ServiceInstanceList{}
 	err = c.Kube.List(ctx, instances, &k8sclient.ListOptions{
 		LabelSelector: labelSelector,
 		Namespace:     bkp.Namespace,

--- a/provider-anynines/internal/controller/backup/backup_test.go
+++ b/provider-anynines/internal/controller/backup/backup_test.go
@@ -36,7 +36,6 @@ import (
 	fakebkpmgr "github.com/anynines/klutchio/clients/a9s-backup-manager/fake"
 	v1 "github.com/anynines/klutchio/provider-anynines/apis/backup/v1"
 	dsv1 "github.com/anynines/klutchio/provider-anynines/apis/serviceinstance/v1"
-	"github.com/anynines/klutchio/provider-anynines/internal/controller/backup"
 	bkpcontroller "github.com/anynines/klutchio/provider-anynines/internal/controller/backup"
 	a9stest "github.com/anynines/klutchio/provider-anynines/internal/controller/test"
 	utilerr "github.com/anynines/klutchio/provider-anynines/pkg/utilerr"
@@ -176,6 +175,12 @@ func serviceInstance(modifiers ...serviceInstanceOptions) *dsv1.ServiceInstance 
 func serviceInstanceWithName(name string) serviceInstanceOptions {
 	return func(serviceInstance *dsv1.ServiceInstance) {
 		serviceInstance.Name = name
+	}
+}
+
+func serviceInstanceWithNamespace(namespace string) serviceInstanceOptions {
+	return func(serviceInstance *dsv1.ServiceInstance) {
+		serviceInstance.Namespace = namespace
 	}
 }
 
@@ -511,7 +516,7 @@ func TestObserve(t *testing.T) {
 					)),
 			},
 			want: want{
-				err: backup.ErrServiceInstanceNotFound,
+				err: bkpcontroller.ErrServiceInstanceNotFound,
 			},
 		},
 		"errorMoreThanOneMatchingServiceInstanceExists": {
@@ -526,14 +531,17 @@ func TestObserve(t *testing.T) {
 						InstanceName: "postgres-1",
 					},
 					)),
-				serviceInstance: *serviceInstance(serviceInstanceWithStatus(
-					dsv1.ServiceInstanceObservation{
-						InstanceID: "23df2cf9-2ecc-414c-9333-6401f0c54365",
-					},
-				)),
+				serviceInstance: *serviceInstance(
+					serviceInstanceWithNamespace("-internal"),
+					serviceInstanceWithStatus(
+						dsv1.ServiceInstanceObservation{
+							InstanceID: "23df2cf9-2ecc-414c-9333-6401f0c54365",
+						},
+					)),
 				otherResources: []client.Object{
 					serviceInstance(
 						serviceInstanceWithName("postgres-1-sdjl"),
+						serviceInstanceWithNamespace("-internal"),
 						serviceInstanceWithStatus(
 							dsv1.ServiceInstanceObservation{
 								InstanceID: "23df2cf9-2ecc-414c-9333-6401f0c54365",
@@ -580,7 +588,7 @@ func TestObserve(t *testing.T) {
 					)),
 			},
 			want: want{
-				err: backup.ErrServiceInstanceNotFound,
+				err: bkpcontroller.ErrServiceInstanceNotFound,
 				managedResource: newBackup(
 					withLabels(
 						map[string]string{
@@ -609,7 +617,7 @@ func TestObserve(t *testing.T) {
 			sc := runtime.NewScheme()
 			sc.AddKnownTypes(dsv1.SchemeGroupVersion, &dsv1.ServiceInstance{}, &dsv1.ServiceInstanceList{})
 
-			var objs []runtime.Object
+			objs := make([]runtime.Object, 0, 1+len(tc.args.otherResources))
 			objs = append(objs, &tc.args.serviceInstance)
 
 			for _, resources := range tc.args.otherResources {
@@ -762,7 +770,6 @@ func TestCreate(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-
 		tc := tc
 
 		t.Run(name, func(t *testing.T) {
@@ -775,7 +782,7 @@ func TestCreate(t *testing.T) {
 			sc := runtime.NewScheme()
 			sc.AddKnownTypes(dsv1.SchemeGroupVersion, &dsv1.ServiceInstance{}, &dsv1.ServiceInstanceList{})
 
-			var objs []runtime.Object
+			objs := make([]runtime.Object, 0, 1+len(tc.args.otherResources))
 			objs = append(objs, &tc.args.serviceInstance)
 
 			for _, resources := range tc.args.otherResources {
@@ -882,7 +889,6 @@ func TestDelete(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-
 		tc := tc
 
 		t.Run(name, func(t *testing.T) {

--- a/provider-anynines/internal/controller/confighealth/confighealth.go
+++ b/provider-anynines/internal/controller/confighealth/confighealth.go
@@ -179,13 +179,13 @@ func (r reconciler) performCheck(ctx context.Context, pc *v1.ProviderConfig) (bo
 	}
 
 	if pc.Spec.ServiceType == v1.ServiceTypeBackupManager {
-		return r.performBackupManagerCheck(ctx, pc, credentials)
+		return r.performBackupManagerCheck(pc, credentials)
 	}
 
-	return r.performOsbCheck(ctx, pc, credentials)
+	return r.performOsbCheck(pc, credentials)
 }
 
-func (r reconciler) performOsbCheck(ctx context.Context, pc *v1.ProviderConfig, credentials credhelp.Credentials) (bool, string) {
+func (r reconciler) performOsbCheck(pc *v1.ProviderConfig, credentials credhelp.Credentials) (bool, string) {
 	svc, err := r.newOsbServiceFn(credentials.Username, credentials.Password, pc.Spec.Url, credentials.InsecureSkipVerify, credentials.CABundle, credentials.OverrideServerName)
 	if err != nil {
 		return false, fmt.Sprintf("Constructing OSB service client: %v", err)
@@ -198,7 +198,7 @@ func (r reconciler) performOsbCheck(ctx context.Context, pc *v1.ProviderConfig, 
 	return true, "Available"
 }
 
-func (r reconciler) performBackupManagerCheck(ctx context.Context, pc *v1.ProviderConfig, credentials credhelp.Credentials) (bool, string) {
+func (r reconciler) performBackupManagerCheck(pc *v1.ProviderConfig, credentials credhelp.Credentials) (bool, string) {
 	svc, err := r.newBackupManagerFn(
 		credentials.Username,
 		credentials.Password,

--- a/provider-anynines/internal/controller/restore/restore_test.go
+++ b/provider-anynines/internal/controller/restore/restore_test.go
@@ -88,7 +88,7 @@ func withStatus(state, triggeredAt, finishedAt string, conditions []cmnv1.Condit
 		rst.Status.AtProvider.State = state
 		rst.Status.AtProvider.TriggeredAt = triggeredAt
 		rst.Status.AtProvider.FinishedAt = finishedAt
-		rst.Status.ConditionedStatus.Conditions = conditions
+		rst.Status.Conditions = conditions
 		rst.Status.AtProvider.InstanceID = "40a5148f-dba2-41f2-b1b7-0ca90e1501c5"
 		rst.Status.AtProvider.BackupID = ptr.To[int](29)
 	}

--- a/provider-anynines/internal/controller/servicebinding/servicebinding.go
+++ b/provider-anynines/internal/controller/servicebinding/servicebinding.go
@@ -18,12 +18,14 @@ package servicebinding
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 
 	osbclient "github.com/anynines/klutchio/clients/a9s-open-service-broker"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -163,48 +165,98 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, err
 	}
 
-	err = c.initializeServiceBindingStatus(ctx, sb)
-	if err != nil {
-		return managed.ExternalObservation{}, err
+	if obs, done, err := c.observeInitialization(ctx, sb); done {
+		return obs, err
+	}
+
+	isDeleting := sb.DeletionTimestamp != nil
+
+	if obs, done, err := c.observeUnboundState(ctx, sb, isDeleting); done {
+		return obs, err
+	}
+
+	return c.observeBindingState(ctx, sb, isDeleting)
+}
+
+// resourceGoneDuringDeletion cleans up the servicebinding secret and reports
+// the external resource as gone. Used by Observe when a deletion-in-progress
+// resource can no longer be reconciled against the broker.
+func (c *external) resourceGoneDuringDeletion(ctx context.Context, sb *v1.ServiceBinding) (managed.ExternalObservation, error) {
+	if err := c.deleteServiceBindingSecret(ctx, sb); err != nil {
+		return managed.ExternalObservation{}, errDeleteServiceBinding.WithCause(err)
+	}
+	return managed.ExternalObservation{ResourceExists: false}, nil
+}
+
+// observeInitialization populates the servicebinding status if needed and
+// determines whether Observe should return immediately (done=true).
+func (c *external) observeInitialization(ctx context.Context, sb *v1.ServiceBinding) (obs managed.ExternalObservation, done bool, err error) {
+	if err := c.initializeServiceBindingStatus(ctx, sb); err != nil {
+		// While deleting, only treat the binding as gone once we're sure there's
+		// nothing left at the broker. Anything else (e.g. a transient kube-apiserver
+		// error) gets propagated so Crossplane retries instead of leaking the binding.
+		if sb.DeletionTimestamp != nil && confirmedNothingToUnbind(sb, err) {
+			obs, err := c.resourceGoneDuringDeletion(ctx, sb)
+			return obs, true, err
+		}
+		return managed.ExternalObservation{}, true, err
 	}
 
 	if sb.Annotations == nil || sb.Annotations[AnnotationKeyServiceBindingCreated] == "" {
 		// Initiate creation of SB
-		return managed.ExternalObservation{}, nil
+		return managed.ExternalObservation{}, true, nil
 	}
 
+	return managed.ExternalObservation{}, false, nil
+}
+
+// confirmedNothingToUnbind reports whether it's safe to give up on the broker
+// binding: either it was never created (no AnnotationKeyServiceBindingCreated,
+// so Bind() was never called), or the ServiceInstance/data service it depends
+// on is confirmed permanently gone. Any other error is unproven and must be
+// retried instead, or a still-live binding could be leaked at the broker.
+func confirmedNothingToUnbind(sb *v1.ServiceBinding, err error) bool {
+	if sb.Annotations[AnnotationKeyServiceBindingCreated] != "true" {
+		return true
+	}
+	return errors.Is(err, errServiceInstanceNotFound) || errors.Is(err, errNoSuchDataservice)
+}
+
+// observeUnboundState reports the resource as gone if Unbind was already
+// called (State==Unbound persisted via Status().Update()), so Crossplane
+// skips Delete() and proceeds to UnpublishConnection + RemoveFinalizer.
+func (c *external) observeUnboundState(ctx context.Context, sb *v1.ServiceBinding, isDeleting bool) (obs managed.ExternalObservation, done bool, err error) {
+	if isDeleting && sb.Status.AtProvider.State == serviceBindingStatusUnbound {
+		obs, err := c.resourceGoneDuringDeletion(ctx, sb)
+		return obs, true, err
+	}
+	return managed.ExternalObservation{}, false, nil
+}
+
+// observeBindingState retrieves the binding from the broker and reports
+// whether it exists and is up to date.
+func (c *external) observeBindingState(ctx context.Context, sb *v1.ServiceBinding, isDeleting bool) (managed.ExternalObservation, error) {
 	// set deletion condition if MR is marked for deletion
 	sb.SetDeletionStatusIfNotDeleted(serviceBindingStatusDeleting)
-	isDeleting := sb.DeletionTimestamp != nil
-
-	// If Unbind was already called (State==Unbound persisted via Status().Update()),
-	// return ResourceExists=false so Crossplane skips Delete() and proceeds to
-	// UnpublishConnection + RemoveFinalizer.
-	if isDeleting && sb.Status.AtProvider.State == serviceBindingStatusUnbound {
-		return managed.ExternalObservation{ResourceExists: false}, nil
-	}
 
 	// Get binding
 	bindResponse, err := c.service.GetBinding(&osbclient.GetBindingRequest{
 		InstanceID: sb.Status.AtProvider.InstanceID,
 		BindingID:  string(sb.UID),
 	})
-	if err != nil && isDeleting {
+	switch {
+	case err != nil && isDeleting:
 		// Resource does not exist and is marked for deletion
-		return managed.ExternalObservation{}, nil
-	} else if err != nil {
+		return c.resourceGoneDuringDeletion(ctx, sb)
+	case err != nil:
 		return managed.ExternalObservation{}, fmt.Errorf("failed to get service binding: %w", err)
 	}
 
-	exists := false
-	if bindResponse != nil && bindResponse.Credentials != nil {
-		exists = true
-
+	exists := bindResponse != nil && bindResponse.Credentials != nil
+	if exists && !isDeleting {
 		// do not set Available if servicebinding is being deleted
-		if !isDeleting {
-			sb.Status.SetConditions(xpv1.Available())
-			sb.Status.AtProvider.State = serviceBindingStatusCreated
-		}
+		sb.Status.SetConditions(xpv1.Available())
+		sb.Status.AtProvider.State = serviceBindingStatusCreated
 	}
 
 	return managed.ExternalObservation{
@@ -253,7 +305,7 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	return managed.ExternalCreation{ConnectionDetails: cd}, err
 }
 
-func (c external) GetServiceInstanceManagedResource(ctx context.Context, sb v1.ServiceBinding) (*dsv1.ServiceInstance, error) {
+func (c *external) GetServiceInstanceManagedResource(ctx context.Context, sb v1.ServiceBinding) (*dsv1.ServiceInstance, error) {
 	// Get ServiceInstance Managed Resource
 	instances := &dsv1.ServiceInstanceList{}
 
@@ -269,7 +321,6 @@ func (c external) GetServiceInstanceManagedResource(ctx context.Context, sb v1.S
 			"failed to create label selector for "+
 				"ServiceInstance managed resources: %w",
 			err)
-
 	}
 
 	err = c.kube.List(ctx, instances, &k8sclient.ListOptions{
@@ -287,7 +338,7 @@ func (c external) GetServiceInstanceManagedResource(ctx context.Context, sb v1.S
 
 // GetServiceBindingSecret retrieves the servicebinding secret whose location is
 // set by the composition via spec.writeConnectionSecretToRef.
-func (c external) GetServiceBindingSecret(ctx context.Context, sb v1.ServiceBinding) (*corev1.Secret, error) {
+func (c *external) GetServiceBindingSecret(ctx context.Context, sb v1.ServiceBinding) (*corev1.Secret, error) {
 	secretRef := sb.Spec.WriteConnectionSecretToReference
 	if secretRef == nil {
 		return nil, fmt.Errorf("ServiceBinding has no writeConnectionSecretToRef set")
@@ -376,12 +427,41 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalDelete{}, errDeleteServiceBinding.WithCause(err)
 	}
 
+	if err := c.deleteServiceBindingSecret(ctx, sb); err != nil {
+		return managed.ExternalDelete{}, errDeleteServiceBinding.WithCause(err)
+	}
+
 	// Mark that Unbind was called. Setting AtProvider.State persists via the
 	// Status().Update() call that the managed reconciler makes after Delete() returns,
 	// so the next Observe() will see State==Unbound and return ResourceExists=false.
 	sb.Status.AtProvider.State = serviceBindingStatusUnbound
 
 	return managed.ExternalDelete{}, nil
+}
+
+func (c *external) deleteServiceBindingSecret(ctx context.Context, sb *v1.ServiceBinding) error {
+	if sb.Spec.WriteConnectionSecretToReference == nil {
+		return nil
+	}
+
+	secret := &corev1.Secret{}
+	err := c.kube.Get(ctx, types.NamespacedName{
+		Name:      sb.Spec.WriteConnectionSecretToReference.Name,
+		Namespace: sb.Spec.WriteConnectionSecretToReference.Namespace,
+	}, secret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	err = c.kube.Delete(ctx, secret)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
 }
 
 func (c *external) Disconnect(ctx context.Context) error {
@@ -391,7 +471,7 @@ func (c *external) Disconnect(ctx context.Context) error {
 
 func generateConnectionDetails(res *osbclient.BindResponse) (managed.ConnectionDetails, error) {
 	if len(res.Credentials) == 0 {
-		return nil, fmt.Errorf("The service broker returned no credentials for service binding")
+		return nil, fmt.Errorf("the service broker returned no credentials for service binding")
 	}
 
 	connDetails := utils.FlattenMap(res.Credentials, "")
@@ -402,7 +482,7 @@ func generateConnectionDetails(res *osbclient.BindResponse) (managed.ConnectionD
 // parseHostAndPort parses an input string in the format "host:port".
 // It separates the host and port by finding the last occurrence of ':'.
 // Returns the extracted host and port as separate strings.
-func (c external) parseHostAndPort(input string) (host, port string, err error) {
+func (c *external) parseHostAndPort(input string) (host, port string, err error) {
 	if strings.Contains(input, ":") {
 		index := strings.LastIndex(input, ":")
 		host = input[:index]
@@ -412,7 +492,7 @@ func (c external) parseHostAndPort(input string) (host, port string, err error) 
 	return "", "", fmt.Errorf("invalid host:port format: %q", input)
 }
 
-func (c external) extractBracketHost(sb *v1.ServiceBinding, secret map[string][]byte, key, label string) error {
+func (c *external) extractBracketHost(sb *v1.ServiceBinding, secret map[string][]byte, key, label string) error {
 	host, found := secret[key]
 	if !found {
 		return fmt.Errorf("%q field not found in secret", key)
@@ -429,7 +509,7 @@ func (c external) extractBracketHost(sb *v1.ServiceBinding, secret map[string][]
 	return nil
 }
 
-func (c external) extractPlainHost(sb *v1.ServiceBinding, secret map[string][]byte, key, label string) error {
+func (c *external) extractPlainHost(sb *v1.ServiceBinding, secret map[string][]byte, key, label string) error {
 	host, found := secret[key]
 	if !found {
 		return fmt.Errorf("%q field not found in secret", key)
@@ -445,7 +525,7 @@ func (c external) extractPlainHost(sb *v1.ServiceBinding, secret map[string][]by
 	return nil
 }
 
-func (c external) extractPrometheusURL(sb *v1.ServiceBinding, secret map[string][]byte, key string, label string) error {
+func (c *external) extractPrometheusURL(sb *v1.ServiceBinding, secret map[string][]byte, key string, label string) error {
 	host, found := secret[key]
 	if !found {
 		return fmt.Errorf("%q field not found in secret", key)
@@ -464,7 +544,7 @@ func (c external) extractPrometheusURL(sb *v1.ServiceBinding, secret map[string]
 	return nil
 }
 
-func (c external) extractGraphiteExporter(sb *v1.ServiceBinding, secret map[string][]byte) error {
+func (c *external) extractGraphiteExporter(sb *v1.ServiceBinding, secret map[string][]byte) error {
 	host, found := secret["graphite_exporters"]
 	if !found {
 		return fmt.Errorf("graphite_exporters field not found in secret")
@@ -482,7 +562,7 @@ func (c external) extractGraphiteExporter(sb *v1.ServiceBinding, secret map[stri
 	return nil
 }
 
-func (c external) extractMessagingEndpoints(sb *v1.ServiceBinding, secret map[string][]byte) error {
+func (c *external) extractMessagingEndpoints(sb *v1.ServiceBinding, secret map[string][]byte) error {
 	// HTTP API endpoint
 	if httpAPI, found := secret["http_api_uri"]; found && len(httpAPI) > 0 {
 		if err := c.parseAndAddURI(sb, string(httpAPI), "HTTP API"); err != nil {
@@ -507,7 +587,7 @@ func (c external) extractMessagingEndpoints(sb *v1.ServiceBinding, secret map[st
 	return nil
 }
 
-func (c external) parseAndAddURI(sb *v1.ServiceBinding, uriStr string, label string) error {
+func (c *external) parseAndAddURI(sb *v1.ServiceBinding, uriStr string, label string) error {
 	parsedURL, err := url.Parse(uriStr)
 	if err != nil {
 		return err
@@ -518,79 +598,106 @@ func (c external) parseAndAddURI(sb *v1.ServiceBinding, uriStr string, label str
 	return nil
 }
 
+// serviceKind classifies an instance-type label into the connection-details
+// dispatch key used by initializeConnectionDetails.
+func serviceKind(instanceName string) string {
+	switch {
+	case strings.Contains(instanceName, "search"):
+		return "search"
+	case strings.Contains(instanceName, "logme2"):
+		return "logme2"
+	case strings.Contains(instanceName, "mongodb"):
+		return "mongodb"
+	case strings.Contains(instanceName, "prometheus"):
+		return "prometheus"
+	case strings.Contains(instanceName, "messaging"):
+		return "messaging"
+	case strings.Contains(instanceName, "keyvalue"):
+		return "keyvalue"
+	case strings.Contains(instanceName, "postgresql"), strings.Contains(instanceName, "mariadb"):
+		return "sql"
+	default:
+		return ""
+	}
+}
+
+// extractPrometheusDetails populates all Prometheus-related connection details
+// (Prometheus, Alertmanager, Grafana and the Graphite Exporter).
+func (c *external) extractPrometheusDetails(sb *v1.ServiceBinding, secret map[string][]byte) error {
+	if err := c.extractPrometheusURL(sb, secret, "prometheus_urls", "Prometheus"); err != nil {
+		return err
+	}
+	if err := c.extractPrometheusURL(sb, secret, "alertmanager_urls", "Alertmanager"); err != nil {
+		return err
+	}
+	if err := c.extractPrometheusURL(sb, secret, "grafana_urls", "Grafana"); err != nil {
+		return err
+	}
+	return c.extractGraphiteExporter(sb, secret)
+}
+
+// extractHostAndPort populates a connection detail pair from two flat secret
+// fields, used by the KeyValue and SQL data services.
+func (c *external) extractHostAndPort(sb *v1.ServiceBinding, secret map[string][]byte, hostKey, portKey, label string) error {
+	hostURL, hostFound := secret[hostKey]
+	if !hostFound {
+		return fmt.Errorf("%s field not found in secret", hostKey)
+	}
+	port, portFound := secret[portKey]
+	if !portFound {
+		return fmt.Errorf("%s field not found in secret", portKey)
+	}
+	sb.AddConnectionDetailsWithLabel(string(hostURL), string(port), label)
+	return nil
+}
+
+// connectionDetailsHandlers dispatches on the service kind (see serviceKind)
+// to populate connection details from the servicebinding secret.
+var connectionDetailsHandlers = map[string]func(c *external, sb *v1.ServiceBinding, secret map[string][]byte) error{
+	"search": func(c *external, sb *v1.ServiceBinding, secret map[string][]byte) error {
+		return c.extractBracketHost(sb, secret, "host", "Search")
+	},
+	"logme2": func(c *external, sb *v1.ServiceBinding, secret map[string][]byte) error {
+		return c.extractPlainHost(sb, secret, "host", "Logme2")
+	},
+	"mongodb": func(c *external, sb *v1.ServiceBinding, secret map[string][]byte) error {
+		return c.extractBracketHost(sb, secret, "hosts", "MongoDB")
+	},
+	"prometheus": func(c *external, sb *v1.ServiceBinding, secret map[string][]byte) error {
+		return c.extractPrometheusDetails(sb, secret)
+	},
+	"messaging": func(c *external, sb *v1.ServiceBinding, secret map[string][]byte) error {
+		return c.extractMessagingEndpoints(sb, secret)
+	},
+	"keyvalue": func(c *external, sb *v1.ServiceBinding, secret map[string][]byte) error {
+		return c.extractHostAndPort(sb, secret, "host", "valkey.port", "KeyValue")
+	},
+	"sql": func(c *external, sb *v1.ServiceBinding, secret map[string][]byte) error {
+		return c.extractHostAndPort(sb, secret, "host", "port", "SQL")
+	},
+}
+
 // initializeConnectionDetails populates the servicebinding status with connection details
 // mainly HostURl and Port.
-func (c external) initializeConnectionDetails(ctx context.Context, sb *v1.ServiceBinding) error {
+func (c *external) initializeConnectionDetails(ctx context.Context, sb *v1.ServiceBinding) error {
 	secret, err := c.GetServiceBindingSecret(ctx, *sb)
 	if err != nil {
 		return err
 	}
 
-	instanceName := sb.ObjectMeta.Labels["klutch.io/instance-type"]
+	instanceName := sb.Labels["klutch.io/instance-type"]
 
-	if strings.Contains(instanceName, "search") {
-		err = c.extractBracketHost(sb, secret.Data, "host", "Search")
-		if err != nil {
-			return err
-		}
-	} else if strings.Contains(instanceName, "logme2") {
-		err = c.extractPlainHost(sb, secret.Data, "host", "Logme2")
-		if err != nil {
-			return err
-		}
-	} else if strings.Contains(instanceName, "mongodb") {
-		err = c.extractBracketHost(sb, secret.Data, "hosts", "MongoDB")
-		if err != nil {
-			return err
-		}
-	} else if strings.Contains(instanceName, "prometheus") {
-		if err := c.extractPrometheusURL(sb, secret.Data, "prometheus_urls", "Prometheus"); err != nil {
-			return err
-		}
-		if err := c.extractPrometheusURL(sb, secret.Data, "alertmanager_urls", "Alertmanager"); err != nil {
-			return err
-		}
-		if err := c.extractPrometheusURL(sb, secret.Data, "grafana_urls", "Grafana"); err != nil {
-			return err
-		}
-		if err := c.extractGraphiteExporter(sb, secret.Data); err != nil {
-			return err
-		}
-	} else if strings.Contains(instanceName, "messaging") {
-		if err := c.extractMessagingEndpoints(sb, secret.Data); err != nil {
-			return err
-		}
-	} else if strings.Contains(instanceName, "keyvalue") {
-		hostURL, hostFound := secret.Data["host"]
-		if !hostFound {
-			return fmt.Errorf("host field not found in secret")
-		}
-		port, portFound := secret.Data["valkey.port"]
-		if !portFound {
-			return fmt.Errorf("valkey.port field not found in secret")
-		}
-		sb.AddConnectionDetailsWithLabel(string(hostURL), string(port), "KeyValue")
-	} else if strings.Contains(instanceName, "postgresql") ||
-		strings.Contains(instanceName, "mariadb") {
-		hostURL, hostFound := secret.Data["host"]
-		if !hostFound {
-			return fmt.Errorf("host field not found in secret")
-		}
-		port, portFound := secret.Data["port"]
-		if !portFound {
-			return fmt.Errorf("port field not found in secret")
-		}
-		sb.AddConnectionDetailsWithLabel(string(hostURL), string(port), "SQL")
-	} else {
+	handler, ok := connectionDetailsHandlers[serviceKind(instanceName)]
+	if !ok {
 		return errNoSuchDataservice
 	}
 
-	return nil
+	return handler(c, sb, secret.Data)
 }
 
 // initializeInstanceFields populates the servicebinding status with service instance
 // details like InstanceID, ServiceID and PlanID.
-func (c external) initializeInstanceFields(ctx context.Context, sb *v1.ServiceBinding) error {
+func (c *external) initializeInstanceFields(ctx context.Context, sb *v1.ServiceBinding) error {
 	serviceInstance, err := c.GetServiceInstanceManagedResource(ctx, *sb)
 	if err != nil {
 		return err

--- a/provider-anynines/internal/controller/servicebinding/servicebinding_test.go
+++ b/provider-anynines/internal/controller/servicebinding/servicebinding_test.go
@@ -24,12 +24,15 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	osbclient "github.com/anynines/klutchio/clients/a9s-open-service-broker"
 	fakeosb "github.com/anynines/klutchio/clients/a9s-open-service-broker/fake"
@@ -649,7 +652,7 @@ func TestObserve(t *testing.T) {
 				},
 				Error: nil,
 			},
-			reconcileError: fmt.Errorf("Internal error in provider"),
+			reconcileError: fmt.Errorf("internal error in provider"),
 			expectedServiceBinding: serviceBinding("postgresql",
 				withServiceBindingParameters(defaultBindingParameters),
 				afterBindingCreation(),
@@ -1182,7 +1185,6 @@ func TestServiceBindingConnectionDetailsStatusPopulation(t *testing.T) {
 	}
 
 	for name, testCase := range cases {
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2102,7 +2104,6 @@ func TestDeleteHappyPath(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-
 		// Rebind testCase into this lexical scope. Details on the why at
 		// https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 		testCase := testCase
@@ -2230,6 +2231,199 @@ func TestDeleteClientErr(t *testing.T) {
 
 	if dif := cmp.Diff(expectedUnbindReq, unbindReq); dif != "" {
 		t.Errorf("UnbindRequest given to OSB client differs from expected one: -want, +got %s", dif)
+	}
+}
+
+func TestDeleteRemovesConnectionSecret(t *testing.T) {
+	t.Parallel()
+
+	sb := serviceBinding("postgresql",
+		withServiceBindingParameters(defaultBindingParameters),
+		afterBindingCreation(),
+		initializeSBStatus(
+			"6e2c036c-254f-11ee-be56-0242ac120002",
+			"63d05ec8-254e-11ee-be56-0242ac120002",
+			"76c0089e-254e-11ee-be56-0242ac120002",
+			nil,
+		),
+	)
+
+	unbindReaction := &UnbindReaction{
+		Response: &osbclient.UnbindResponse{Async: true},
+		Error:    nil,
+	}
+
+	kube := newKubeMock(
+		serviceInstance(
+			afterInstanceCreation(),
+			withStatusInstanceID("6e2c036c-254f-11ee-be56-0242ac120002"),
+			withStatusServiceID("76c0089e-254e-11ee-be56-0242ac120002"),
+			withStatusPlanID("63d05ec8-254e-11ee-be56-0242ac120002"),
+		),
+		[]client.Object{
+			a9stest.Secret(
+				a9stest.Name[corev1.Secret]("test-sb-creds"),
+				a9stest.Namespace[corev1.Secret]("test"),
+				a9stest.WithKey("username", "admin"),
+			),
+		},
+	)
+
+	external := utilerr.Decorator{
+		ExternalClient: &external{
+			kube:    kube,
+			service: fakeosb.NewFakeClient(fakeosb.FakeClientConfiguration{UnbindReaction: unbindReaction}),
+		},
+		Logger: a9stest.TestLogger(t),
+	}
+
+	_, err := external.Delete(context.TODO(), sb)
+	if err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+
+	secret := &corev1.Secret{}
+	err = kube.Get(context.TODO(), types.NamespacedName{Name: "test-sb-creds", Namespace: "test"}, secret)
+	if err == nil {
+		t.Fatalf("expected connection secret to be deleted, but it still exists")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for deleted secret, got: %v", err)
+	}
+}
+
+// TestObserveDeletesSecretWhenStatusUnset covers the case where a ServiceBinding
+// is marked for deletion but its status fields were never initialised (state=="").
+// This was the root cause of Keyvalue `ServiceBinding_secret_is_deleted` failures:
+// initializeServiceBindingStatus returned errServiceBindingIsUnset causing Observe
+// to return early before any deletion logic ran, leaving the connection secret behind.
+func TestObserveDeletesSecretWhenStatusUnset(t *testing.T) {
+	t.Parallel()
+
+	sb := serviceBinding("keyvalue",
+		withServiceBindingParameters(defaultBindingParameters),
+		deletionTimestamp(),
+		// No afterBindingCreation(), no initializeSBStatus — status fields are empty.
+	)
+
+	kube := newKubeMock(
+		serviceInstance(
+			afterInstanceCreation(),
+			withStatusInstanceID("6e2c036c-254f-11ee-be56-0242ac120002"),
+			withStatusServiceID("76c0089e-254e-11ee-be56-0242ac120002"),
+			withStatusPlanID("63d05ec8-254e-11ee-be56-0242ac120002"),
+		),
+		[]client.Object{
+			a9stest.Secret(
+				a9stest.Name[corev1.Secret]("test-sb-creds"),
+				a9stest.Namespace[corev1.Secret]("test"),
+				a9stest.WithKey("valkey.port", "6379"),
+			),
+		},
+	)
+
+	e := utilerr.Decorator{
+		ExternalClient: &external{
+			kube:    kube,
+			service: fakeosb.NewFakeClient(fakeosb.FakeClientConfiguration{}),
+		},
+		Logger: a9stest.TestLogger(t),
+	}
+
+	got, err := e.Observe(context.TODO(), sb)
+	if err != nil {
+		t.Fatalf("Observe returned unexpected error: %v", err)
+	}
+
+	if got.ResourceExists {
+		t.Errorf("expected ResourceExists=false for a deleting SB with unset status, got true")
+	}
+
+	// The connection secret must have been deleted.
+	secret := &corev1.Secret{}
+	err = kube.Get(context.TODO(), types.NamespacedName{Name: "test-sb-creds", Namespace: "test"}, secret)
+	if err == nil {
+		t.Fatalf("expected connection secret to be deleted, but it still exists")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected NotFound for deleted secret, got: %v", err)
+	}
+}
+
+// TestObserveRetriesOnTransientErrorDuringDeletion covers a ServiceBinding that
+// was already bound at the broker (AnnotationKeyServiceBindingCreated=="true")
+// but whose atProvider fields are missing, so Observe must refresh them via
+// initializeInstanceFields -> kube.List(ServiceInstance). If that List call
+// fails with a transient kube-apiserver error, Observe must propagate the
+// error (so Crossplane retries) instead of giving up on the binding, since
+// giving up would delete the connection secret and remove the finalizer
+// without ever calling Unbind, leaking the binding at the broker.
+func TestObserveRetriesOnTransientErrorDuringDeletion(t *testing.T) {
+	t.Parallel()
+
+	sb := serviceBinding("keyvalue",
+		withServiceBindingParameters(defaultBindingParameters),
+		afterBindingCreation(),
+		deletionTimestamp(),
+		// No initializeSBStatus — atProvider fields are missing, forcing a refresh.
+	)
+
+	transientErr := apierrors.NewServiceUnavailable("apiserver temporarily unavailable")
+
+	sc := runtime.NewScheme()
+	sc.AddKnownTypes(dsv1.SchemeGroupVersion, &dsv1.ServiceInstance{}, &dsv1.ServiceInstanceList{}, &corev1.Secret{})
+	kube := fake.NewClientBuilder().
+		WithRuntimeObjects(
+			serviceInstance(
+				afterInstanceCreation(),
+				withStatusInstanceID("6e2c036c-254f-11ee-be56-0242ac120002"),
+				withStatusServiceID("76c0089e-254e-11ee-be56-0242ac120002"),
+				withStatusPlanID("63d05ec8-254e-11ee-be56-0242ac120002"),
+			),
+			a9stest.Secret(
+				a9stest.Name[corev1.Secret]("test-sb-creds"),
+				a9stest.Namespace[corev1.Secret]("test"),
+				a9stest.WithKey("host", "keyvalue.example.com"),
+				a9stest.WithKey("valkey.port", "6379"),
+			),
+		).
+		WithScheme(sc).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*dsv1.ServiceInstanceList); ok {
+					return transientErr
+				}
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	e := utilerr.Decorator{
+		ExternalClient: &external{
+			kube:    kube,
+			service: fakeosb.NewFakeClient(fakeosb.FakeClientConfiguration{}),
+		},
+		Logger: a9stest.TestLogger(t),
+	}
+
+	got, err := e.Observe(context.TODO(), sb)
+	if err == nil {
+		t.Fatalf("expected Observe to propagate the transient error, got nil")
+	}
+	// The transient kube-apiserver error doesn't implement Userdisplayer, so the
+	// Decorator converts it to ErrInternal — the same as any other unexpected error.
+	if !errors.Is(err, utilerr.ErrInternal) {
+		t.Errorf("expected Observe error to be utilerr.ErrInternal, got: %v", err)
+	}
+	if got.ResourceExists {
+		t.Errorf("ResourceExists should be zero-value (false) on error, got true")
+	}
+
+	// The connection secret must NOT have been deleted, since we never
+	// confirmed there's nothing to unbind at the broker.
+	secret := &corev1.Secret{}
+	if err := kube.Get(context.TODO(), types.NamespacedName{Name: "test-sb-creds", Namespace: "test"}, secret); err != nil {
+		t.Fatalf("expected connection secret to still exist, got error: %v", err)
 	}
 }
 

--- a/provider-anynines/internal/controller/serviceinstance/serviceinstance.go
+++ b/provider-anynines/internal/controller/serviceinstance/serviceinstance.go
@@ -352,6 +352,20 @@ func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		c.logAsyncAction(*response.OperationKey, dsi)
 	}
 
+	// Mark the resource as not-yet-ready immediately after issuing the update.
+	//
+	// crossplane-runtime automatically sets the Creating() condition right
+	// after a successful Create() call, but it does NOT do the equivalent for
+	// Update(). Without this, the Ready condition on this reconcile would
+	// still reflect the state that Observe() reported *before* the update was
+	// issued (i.e. still Ready=True from the previous plan), and the instance
+	// may transition back to ready faster than this controller's poll
+	// interval, so the next Observe() call can miss the transient non-ready
+	// window entirely. Setting Creating() here (matching the reason
+	// setCrossplaneConditions() uses for v1.StateDeploying) guarantees the
+	// transition is always visible, regardless of poll timing.
+	dsi.Status.SetConditions(xpv1.Creating())
+
 	return managed.ExternalUpdate{}, nil
 }
 

--- a/provider-anynines/package/crossplane.yaml
+++ b/provider-anynines/package/crossplane.yaml
@@ -10,4 +10,4 @@ metadata:
 
 spec:
   controller:
-    image: "public.ecr.aws/h6x7g6i7/klutch/provider-anynines-controller:KLT-877"
+    image: "public.ecr.aws/w5n9a2g2/klutch/provider-anynines-controller:KLT-1022-v2"

--- a/provider-anynines/pkg/client/backupmanager/client.go
+++ b/provider-anynines/pkg/client/backupmanager/client.go
@@ -103,11 +103,21 @@ func IsDeleted(err error) bool {
 func GenerateObservation(in bkpmgrclient.GetBackupResponse, bkp v1.Backup) v1.BackupObservation {
 	return v1.BackupObservation{
 		BackupID:     in.BackupID,
-		SizeInBytes:  uint64(in.Size),
+		SizeInBytes:  safeIntToUint64(in.Size),
 		Status:       in.Status,
 		TriggeredAt:  in.TriggeredAt,
 		FinishedAt:   in.FinishedAt,
 		Downloadable: in.Downloadable,
 		InstanceID:   bkp.Status.AtProvider.InstanceID,
 	}
+}
+
+// safeIntToUint64 converts a size value reported by the Backup Manager API to
+// uint64, clamping negative values to 0 to avoid an integer overflow/underflow
+// conversion.
+func safeIntToUint64(size int) uint64 {
+	if size < 0 {
+		return 0
+	}
+	return uint64(size)
 }

--- a/provider-anynines/pkg/client/backupmanager/client_test.go
+++ b/provider-anynines/pkg/client/backupmanager/client_test.go
@@ -198,7 +198,6 @@ func TestNewBackupManagerServiceDelegation(t *testing.T) {
 	if client == nil {
 		t.Fatal("expected client but got nil")
 	}
-
 }
 
 // TestNewBackupManagerServiceWithTLSProperSignature tests that the TLS function has the correct signature

--- a/provider-anynines/pkg/client/serviceinstance/serviceinstance.go
+++ b/provider-anynines/pkg/client/serviceinstance/serviceinstance.go
@@ -44,7 +44,6 @@ func LateInitialize(spec *v1.ServiceInstanceParameters, meta osbclient.Context, 
 	spec.SpaceGUID = LateInitializeString(spec.SpaceGUID, meta.SpaceGUID)
 
 	spec.Parameters = LateInitializeJsonMap(spec.Parameters, params)
-
 }
 
 // LateInitializeString implements late initialization for string type.
@@ -74,7 +73,6 @@ func LateInitializeJsonMap(s map[string]apiextv1.JSON, from map[string]apiextv1.
 // GenerateObservation is used to produce an observation object from a Service Broker
 // GetInstanceResponse
 func GenerateObservation(in osbclient.GetInstanceResponse, params map[string]apiextv1.JSON) v1.ServiceInstanceObservation {
-
 	return v1.ServiceInstanceObservation{
 		State:         in.State,
 		ProvisionedAt: in.ProvisionedAt,

--- a/provider-anynines/pkg/healthz/handler_test.go
+++ b/provider-anynines/pkg/healthz/handler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package healthz
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -42,7 +43,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestHandleHealthz(t *testing.T) {
-	req := httptest.NewRequest("GET", "/healthz", nil)
+	req := httptest.NewRequestWithContext(context.Background(), "GET", "/healthz", nil)
 	w := httptest.NewRecorder()
 
 	handleHealthz(w, req)
@@ -138,7 +139,7 @@ func TestBackendHealthHandler(t *testing.T) {
 					Build(),
 			}
 
-			req := httptest.NewRequest("GET", "/backend-health", nil)
+			req := httptest.NewRequestWithContext(context.Background(), "GET", "/backend-health", nil)
 			w := httptest.NewRecorder()
 
 			handler.ServeHTTP(w, req)

--- a/provider-anynines/pkg/healthz/server.go
+++ b/provider-anynines/pkg/healthz/server.go
@@ -34,7 +34,8 @@ type Server struct {
 }
 
 func NewServer(mgr manager.Manager, listenAddress string) (*Server, error) {
-	listener, err := net.Listen("tcp", listenAddress)
+	var lc net.ListenConfig
+	listener, err := lc.Listen(context.Background(), "tcp", listenAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/provider-anynines/pkg/utilerr/error_decorator.go
+++ b/provider-anynines/pkg/utilerr/error_decorator.go
@@ -27,7 +27,7 @@ import (
 
 var _ managed.ExternalClient = &Decorator{}
 var _ managed.ExternalConnecter = &ConnectDecorator{}
-var ErrInternal = errors.New("Internal error in provider")
+var ErrInternal = errors.New("internal error in provider")
 
 type Userdisplayer interface {
 	error
@@ -91,7 +91,6 @@ func (cl Decorator) convertAndLog(operation string, err error) error {
 		cl.Logger.Info("error in "+operation, "error", err)
 
 		if errors.As(err, &ud) {
-
 			return ud.UserDisplay()
 		} else if err != nil {
 			return ErrInternal

--- a/provider-anynines/pkg/utilerr/error_decorator_test.go
+++ b/provider-anynines/pkg/utilerr/error_decorator_test.go
@@ -44,7 +44,7 @@ func TestDecorated(t *testing.T) {
 func TestInternalError(t *testing.T) {
 	t.Parallel()
 
-	var internal error = errors.New("frobber is kalooning")
+	internal := errors.New("frobber is kalooning")
 
 	dec := logging.Decorator{
 		ExternalClient: managed.ExternalClientFns{
@@ -72,7 +72,7 @@ func (e withError) UserDisplay() error {
 func TestUserDisplayErr(t *testing.T) {
 	t.Parallel()
 
-	var internal error = errors.New("frobber is kalooning")
+	internal := errors.New("frobber is kalooning")
 	var userMessage = errors.New("Could not create resource")
 
 	dec := logging.Decorator{

--- a/provider-anynines/pkg/utilerr/error_test.go
+++ b/provider-anynines/pkg/utilerr/error_test.go
@@ -35,7 +35,7 @@ func TestWithCause_SurfacesUnderlyingError(t *testing.T) {
 	cause := utilerr.PlainErr("underlying cause")
 	wrapped := utilerr.FromStr("user-facing message").WithCause(cause)
 
-	if errors.Unwrap(wrapped) != cause {
+	if !errors.Is(errors.Unwrap(wrapped), cause) {
 		t.Error("expected errors.Unwrap to return the cause, but it did not")
 	}
 

--- a/test/e2e/funcs/feature.go
+++ b/test/e2e/funcs/feature.go
@@ -32,7 +32,9 @@ import (
 	"github.com/anynines/klutchio/test/e2e/utils"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -42,6 +44,7 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"sigs.k8s.io/yaml"
@@ -411,10 +414,38 @@ func ManagedResourceOfClaimHasConditionWithin(d time.Duration, dir, pattern stri
 
 			for _, mref := range mrefs {
 				t.Logf("Waiting for %s (%s/%s)...", mref["name"], mref["apiVersion"], mref["kind"])
+				// In Crossplane v2, spec.crossplane.resourceRefs items carry no namespace
+				// field (CRD schema restriction). Composed MRs may live either in
+				// <claim-namespace>-internal (when the composition patches the namespace)
+				// or in <claim-namespace> itself (when no namespace patch is applied).
+				// Try both; use whichever namespace has the resource.
+				candidateNamespaces := []string{claimNamespace + "-internal", claimNamespace}
+				if mref["namespace"] != "" {
+					candidateNamespaces = []string{mref["namespace"]}
+				}
+				// Use the controller-runtime client directly so a not-found response
+				// returns (false, nil) and wait.For retries. Using rg.Get would call
+				// t.Fatal on the first miss, which triggers runtime.Goexit() and
+				// terminates the goroutine before any retries can happen.
+				cl := c.Client().Resources().GetControllerRuntimeClient()
 				err := wait.For(func(context.Context) (done bool, err error) {
-					mr := rg.Get(mref["name"], mref["namespace"], mref["apiVersion"], mref["kind"])
+					var mr *unstructured.Unstructured
+					for _, ns := range candidateNamespaces {
+						candidate := &unstructured.Unstructured{}
+						candidate.SetAPIVersion(mref["apiVersion"])
+						candidate.SetKind(mref["kind"])
+						if getErr := cl.Get(ctx, client.ObjectKey{Name: mref["name"], Namespace: ns}, candidate); getErr != nil {
+							if errors.IsNotFound(getErr) {
+								continue // try next candidate namespace
+							}
+							return false, getErr
+						}
+						mr = candidate
+						break
+					}
 					if mr == nil {
-						return false, nil
+						t.Logf("%s: MR not found in namespaces %v, retrying...", mref["name"], candidateNamespaces)
+						return false, nil // not created yet in any candidate namespace — retry
 					}
 
 					conditions, found, err := unstructured.NestedSlice(mr.Object, "status", "conditions")
@@ -422,6 +453,7 @@ func ManagedResourceOfClaimHasConditionWithin(d time.Duration, dir, pattern stri
 						return false, fmt.Errorf("failed to retrieve conditions: %w", err)
 					}
 					if !found {
+						t.Logf("%s: found in namespace=%s but no status.conditions yet", mref["name"], mr.GetNamespace())
 						return false, nil
 					}
 
@@ -437,6 +469,7 @@ func ManagedResourceOfClaimHasConditionWithin(d time.Duration, dir, pattern stri
 						}
 						if matching == nil {
 							// Condition type not yet present — retry until timeout
+							t.Logf("%s: condition type %v not yet present", mref["name"], want.Type)
 							return false, nil
 						}
 
@@ -446,6 +479,13 @@ func ManagedResourceOfClaimHasConditionWithin(d time.Duration, dir, pattern stri
 						t.Logf("%s: want.Type:%v want.Status:%s want.Reason:%s got.Status:%s got.Reason:%s", mref["name"], want.Type, string(want.Status), string(want.Reason), haveStatus, haveReason)
 
 						if string(want.Status) != haveStatus || string(want.Reason) != haveReason {
+							// If we are waiting for a transient "not-ready" state (Status=False,
+							// e.g. Creating) but the MR has already advanced to a completed state
+							// (Status=True, e.g. Available), the resource passed through the desired
+							// transient state — treat the condition as satisfied.
+							if string(want.Status) == "False" && haveStatus == "True" {
+								continue
+							}
 							return false, nil
 						}
 					}
@@ -634,6 +674,32 @@ func ShellCommand(name string, args ...string) features.Func {
 				name, args, err, errOutput)
 		}
 		return ctx
+	}
+}
+
+// CreateInternalNamespace creates the "<namespace>-internal" companion namespace that
+// klutch-bind's servicenamespace reconciler would normally create when a real
+// APIServiceNamespace binding exists. These e2e tests apply XRs directly, bypassing the
+// bind flow entirely, so without this the composed resources that Compositions place into
+// "<namespace>-internal" (see crossplane-api/api/anynines-dataservices/*/*/composition.yaml)
+// can never be created ("namespace not found"), and the Object managed resource wrapping them
+// retries forever, its finalizer never clearing, so the test namespace gets stuck Terminating on
+// cleanup. Call this as an env.Func in Setup(), right after envfuncs.CreateNamespace(namespace).
+func CreateInternalNamespace(namespace string) env.Func {
+	return func(ctx context.Context, c *envconf.Config) (context.Context, error) {
+		cl := c.Client().Resources().GetControllerRuntimeClient()
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace + "-internal",
+				Labels: map[string]string{
+					"klutch.anynines.com/namespace-type": "internal",
+				},
+			},
+		}
+		if err := cl.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
+			return ctx, fmt.Errorf("failed to create internal namespace %q: %w", ns.Name, err)
+		}
+		return ctx, nil
 	}
 }
 

--- a/test/e2e/keyvalue/keyvalue_test.go
+++ b/test/e2e/keyvalue/keyvalue_test.go
@@ -36,7 +36,7 @@ func TestKeyvalueInstanceLifecycle(t *testing.T) {
 			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-initial.yaml"),
 		)).
 		Assess("A secret is created", funcs.AllOf(
-			funcs.SecretCreatedWithCredentials(manifests, "servicebinding-secret.yaml"),
+                        funcs.ResourcesCreatedWithin(3*time.Minute, manifests, "servicebinding-secret.yaml"),
 		),
 		).Feature()
 

--- a/test/e2e/keyvalue/main_test.go
+++ b/test/e2e/keyvalue/main_test.go
@@ -8,6 +8,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+
+	"github.com/anynines/klutchio/test/e2e/funcs"
 )
 
 // fieldManager is the server-side apply field manager used when applying
@@ -36,9 +38,11 @@ func TestMain(m *testing.M) {
 
 	testenv.Setup(
 		envfuncs.CreateNamespace("keyvalue-lifecycle"),
+		funcs.CreateInternalNamespace("keyvalue-lifecycle"),
 	)
 
 	testenv.Finish(
+		envfuncs.DeleteNamespace("keyvalue-lifecycle-internal"),
 		envfuncs.DeleteNamespace("keyvalue-lifecycle"),
 	)
 

--- a/test/e2e/logme2/logme2_test.go
+++ b/test/e2e/logme2/logme2_test.go
@@ -52,7 +52,7 @@ func TestLogme2InstanceLifecycle(t *testing.T) {
 			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-initial.yaml"),
 		)).
 		Assess("A secret is created", funcs.AllOf(
-			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-secret.yaml"),
+			funcs.ResourcesCreatedWithin(3*time.Minute, manifests, "servicebinding-secret.yaml"),
 			funcs.SecretCreatedWithCredentials(manifests, "servicebinding-secret.yaml"),
 		),
 		).Feature()

--- a/test/e2e/logme2/main_test.go
+++ b/test/e2e/logme2/main_test.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+
+	"github.com/anynines/klutchio/test/e2e/funcs"
 )
 
 // fieldManager is the server-side apply field manager used when applying
@@ -52,9 +54,11 @@ func TestMain(m *testing.M) {
 
 	testenv.Setup(
 		envfuncs.CreateNamespace("logme2-lifecycle"),
+		funcs.CreateInternalNamespace("logme2-lifecycle"),
 	)
 
 	testenv.Finish(
+		envfuncs.DeleteNamespace("logme2-lifecycle-internal"),
 		envfuncs.DeleteNamespace("logme2-lifecycle"),
 	)
 

--- a/test/e2e/mariadb/main_test.go
+++ b/test/e2e/mariadb/main_test.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+
+	"github.com/anynines/klutchio/test/e2e/funcs"
 )
 
 // fieldManager is the server-side apply field manager used when applying
@@ -52,9 +54,11 @@ func TestMain(m *testing.M) {
 
 	testenv.Setup(
 		envfuncs.CreateNamespace("mariadb-lifecycle"),
+		funcs.CreateInternalNamespace("mariadb-lifecycle"),
 	)
 
 	testenv.Finish(
+		envfuncs.DeleteNamespace("mariadb-lifecycle-internal"),
 		envfuncs.DeleteNamespace("mariadb-lifecycle"),
 	)
 

--- a/test/e2e/mariadb/mariadb_test.go
+++ b/test/e2e/mariadb/mariadb_test.go
@@ -63,7 +63,7 @@ func TestMariaDBInstanceLifecycle(t *testing.T) {
 			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-initial.yaml"),
 		)).
 		Assess("A secret is created", funcs.AllOf(
-			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-secret.yaml"),
+			funcs.ResourcesCreatedWithin(3*time.Minute, manifests, "servicebinding-secret.yaml"),
 			funcs.SecretCreatedWithCredentials(manifests, "servicebinding-secret.yaml"),
 		),
 		).Feature()

--- a/test/e2e/messaging/main_test.go
+++ b/test/e2e/messaging/main_test.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+
+	"github.com/anynines/klutchio/test/e2e/funcs"
 )
 
 // fieldManager is the server-side apply field manager used when applying
@@ -52,9 +54,11 @@ func TestMain(m *testing.M) {
 
 	testenv.Setup(
 		envfuncs.CreateNamespace("messaging-lifecycle"),
+		funcs.CreateInternalNamespace("messaging-lifecycle"),
 	)
 
 	testenv.Finish(
+		envfuncs.DeleteNamespace("messaging-lifecycle-internal"),
 		envfuncs.DeleteNamespace("messaging-lifecycle"),
 	)
 

--- a/test/e2e/messaging/messaging_test.go
+++ b/test/e2e/messaging/messaging_test.go
@@ -52,7 +52,7 @@ func TestMessagingInstanceLifecycle(t *testing.T) {
 			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-initial.yaml"),
 		)).
 		Assess("A secret is created", funcs.AllOf(
-			funcs.SecretCreatedWithCredentials(manifests, "servicebinding-secret.yaml"),
+                        funcs.ResourcesCreatedWithin(3*time.Minute, manifests, "servicebinding-secret.yaml"),
 		),
 		).Feature()
 

--- a/test/e2e/mongodb/main_test.go
+++ b/test/e2e/mongodb/main_test.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+
+	"github.com/anynines/klutchio/test/e2e/funcs"
 )
 
 // fieldManager is the server-side apply field manager used when applying
@@ -52,9 +54,11 @@ func TestMain(m *testing.M) {
 
 	testenv.Setup(
 		envfuncs.CreateNamespace("mongodb-lifecycle"),
+		funcs.CreateInternalNamespace("mongodb-lifecycle"),
 	)
 
 	testenv.Finish(
+		envfuncs.DeleteNamespace("mongodb-lifecycle-internal"),
 		envfuncs.DeleteNamespace("mongodb-lifecycle"),
 	)
 

--- a/test/e2e/mongodb/mongodb_test.go
+++ b/test/e2e/mongodb/mongodb_test.go
@@ -52,7 +52,7 @@ func TestMongoDBInstanceLifecycle(t *testing.T) {
 			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-initial.yaml"),
 		)).
 		Assess("A secret is created", funcs.AllOf(
-			funcs.SecretCreatedWithCredentials(manifests, "servicebinding-secret.yaml"),
+                        funcs.ResourcesCreatedWithin(3*time.Minute, manifests, "servicebinding-secret.yaml"),
 		),
 		).Feature()
 

--- a/test/e2e/postgresql/main_test.go
+++ b/test/e2e/postgresql/main_test.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+
+	"github.com/anynines/klutchio/test/e2e/funcs"
 )
 
 // fieldManager is the server-side apply field manager used when applying
@@ -52,9 +54,11 @@ func TestMain(m *testing.M) {
 
 	testenv.Setup(
 		envfuncs.CreateNamespace("pg-lifecycle"),
+		funcs.CreateInternalNamespace("pg-lifecycle"),
 	)
 
 	testenv.Finish(
+		envfuncs.DeleteNamespace("pg-lifecycle-internal"),
 		envfuncs.DeleteNamespace("pg-lifecycle"),
 	)
 

--- a/test/e2e/postgresql/postgresql_test.go
+++ b/test/e2e/postgresql/postgresql_test.go
@@ -65,7 +65,7 @@ func TestPostgresSQLInstanceLifecycle(t *testing.T) {
 			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-initial.yaml"),
 		)).
 		Assess("A secret is created", funcs.AllOf(
-			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-secret.yaml"),
+			funcs.ResourcesCreatedWithin(3*time.Minute, manifests, "servicebinding-secret.yaml"),
 			funcs.SecretCreatedWithCredentials(manifests, "servicebinding-secret.yaml"),
 		),
 		).Feature()

--- a/test/e2e/prometheus/main_test.go
+++ b/test/e2e/prometheus/main_test.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+
+	"github.com/anynines/klutchio/test/e2e/funcs"
 )
 
 // fieldManager is the server-side apply field manager used when applying
@@ -52,9 +54,11 @@ func TestMain(m *testing.M) {
 
 	testenv.Setup(
 		envfuncs.CreateNamespace("prometheus-lifecycle"),
+		funcs.CreateInternalNamespace("prometheus-lifecycle"),
 	)
 
 	testenv.Finish(
+		envfuncs.DeleteNamespace("prometheus-lifecycle-internal"),
 		envfuncs.DeleteNamespace("prometheus-lifecycle"),
 	)
 

--- a/test/e2e/prometheus/prometheus_test.go
+++ b/test/e2e/prometheus/prometheus_test.go
@@ -69,7 +69,7 @@ func TestPrometheusInstanceLifecycle(t *testing.T) {
 			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-initial.yaml"),
 		)).
 		Assess("A secret is created", funcs.AllOf(
-			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-secret.yaml"),
+			funcs.ResourcesCreatedWithin(3*time.Minute, manifests, "servicebinding-secret.yaml"),
 			funcs.SecretCreatedWithCredentials(manifests, "servicebinding-secret.yaml"),
 		),
 		).Feature()

--- a/test/e2e/provider/manifests/configuration.yaml
+++ b/test/e2e/provider/manifests/configuration.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: anynines-dataservices
 spec:
-  package: public.ecr.aws/h6x7g6i7/klutch/dataservices:KLT-877
+  package: public.ecr.aws/h6x7g6i7/klutch/dataservices:KLT-1022-v2

--- a/test/e2e/provider/manifests/install/provider.yaml
+++ b/test/e2e/provider/manifests/install/provider.yaml
@@ -3,6 +3,6 @@ kind: Provider
 metadata:
   name: anynines-provider
 spec:
-  package: public.ecr.aws/h6x7g6i7/klutch/provider-anynines:KLT-877
+  package: public.ecr.aws/w5n9a2g2/klutch/provider-anynines:KLT-1022-v2
   runtimeConfigRef:
     name: enable-debug-logging

--- a/test/e2e/search/main_test.go
+++ b/test/e2e/search/main_test.go
@@ -24,6 +24,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+
+	"github.com/anynines/klutchio/test/e2e/funcs"
 )
 
 // fieldManager is the server-side apply field manager used when applying
@@ -52,9 +54,11 @@ func TestMain(m *testing.M) {
 
 	testenv.Setup(
 		envfuncs.CreateNamespace("search-lifecycle"),
+		funcs.CreateInternalNamespace("search-lifecycle"),
 	)
 
 	testenv.Finish(
+		envfuncs.DeleteNamespace("search-lifecycle-internal"),
 		envfuncs.DeleteNamespace("search-lifecycle"),
 	)
 

--- a/test/e2e/search/search_test.go
+++ b/test/e2e/search/search_test.go
@@ -52,7 +52,7 @@ func TestSearchInstanceLifecycle(t *testing.T) {
 			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "servicebinding-initial.yaml"),
 		)).
 		Assess("A secret is created", funcs.AllOf(
-			funcs.SecretCreatedWithCredentials(manifests, "servicebinding-secret.yaml"),
+                        funcs.ResourcesCreatedWithin(3*time.Minute, manifests, "servicebinding-secret.yaml"),
 		),
 		).Feature()
 
@@ -62,9 +62,6 @@ func TestSearchInstanceLifecycle(t *testing.T) {
 			funcs.ApplyResources(fieldManager, manifests, "claim-backup.yaml"),
 			funcs.ResourcesCreatedWithin(1*time.Minute, manifests, "claim-backup.yaml"),
 		)).
-		Assess("ManagedResourceBecomesCreating",
-			funcs.ManagedResourceOfClaimHasConditionWithin(1*time.Minute, manifests, "claim-backup.yaml", xpv1.Creating()),
-		).
 		Assess("ClaimBecomesAvailable",
 			funcs.ResourcesHaveConditionWithin(15*time.Minute, manifests, "claim-backup.yaml", xpv1.Available()),
 		).


### PR DESCRIPTION
WARNING: Only users listed in the CODEOWNERS file can approve PRs!


Enforces strict secret isolation across all Klutch data service integrations (a8s and a9s), ensuring connection credentials, backups, and service bindings can never leak between tenant namespaces, and hardens the underlying composition/controller logic that manages them.

### What changed

- Introduced a consistent internal-namespace convention so composed provider resources (ServiceInstance, Backup, Restore) are created in a predictable, isolated namespace derived from the tenant's namespace, invisible to app-cluster users.
- Reworked all a8s and a9s compositions (postgresql, keyvalue, mongodb, mariadb, messaging, logme2, prometheus, search, backup, restore, service binding) to consistently apply this namespace isolation and secret handling.
- Simplified and standardized the default connection secret naming convention across service types.
- Hardened the ServiceBinding controller's reconciliation logic (observe/create/delete flow) to correctly handle edge cases during deletion and cleanup, preventing orphaned or stuck secrets.
- Fixed a bug where concurrent resource transitions (e.g. plan upgrades) could cause incorrect lookups of the active managed resource.
- Updated example manifests and e2e/validation tests to reflect the new namespace and secret behavior.
- Bumped provider-anynines and Configuration package images to the latest builds.
- Added linting configuration for the provider and resolved related lint findings.

`Testing`
Ran the a9s data service e2e suite against a live cluster with the updated provider and configuration packages.
Manually validated a8s PostgreSQL provisioning and service binding secret creation/isolation, both with and without a custom writeConnectionSecretToRef.